### PR TITLE
Member 삭제 로직 수정

### DIFF
--- a/src/main/generated/com/example/tomyongji/my/mapper/MyMapperImpl.java
+++ b/src/main/generated/com/example/tomyongji/my/mapper/MyMapperImpl.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Component;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2024-12-30T18:11:46+0900",
+    date = "2025-01-14T17:54:49+0900",
     comments = "version: 1.5.0.Final, compiler: javac, environment: Java 17 (Oracle Corporation)"
 )
 @Component
@@ -30,6 +30,7 @@ public class MyMapperImpl implements MyMapper {
         if ( id != null ) {
             myDto.studentClubId( id );
         }
+        myDto.college( user.getCollegeName() );
         myDto.name( user.getName() );
         myDto.studentNum( user.getStudentNum() );
 
@@ -58,6 +59,7 @@ public class MyMapperImpl implements MyMapper {
 
         Member.MemberBuilder member = Member.builder();
 
+        member.id( saveMemberDto.getId() );
         member.studentNum( saveMemberDto.getStudentNum() );
         member.name( saveMemberDto.getName() );
 

--- a/src/main/java/com/example/tomyongji/auth/repository/ClubVerificationRepository.java
+++ b/src/main/java/com/example/tomyongji/auth/repository/ClubVerificationRepository.java
@@ -10,4 +10,6 @@ import java.util.Optional;
 @Repository
 public interface ClubVerificationRepository extends JpaRepository<ClubVerification, Long> {
     Optional<ClubVerification> findByStudentNum(String studentNum);
+
+    void deleteByStudentNum(String studentNum);
 }

--- a/src/main/java/com/example/tomyongji/auth/service/CustomUserDetails.java
+++ b/src/main/java/com/example/tomyongji/auth/service/CustomUserDetails.java
@@ -35,6 +35,8 @@ public class CustomUserDetails implements UserDetails {
         return user.getUserId();
     }
 
+    public User getUser() {return user;}
+
     // 기타 UserDetails 메소드 구현
 }
 

--- a/src/main/java/com/example/tomyongji/receipt/controller/ReceiptController.java
+++ b/src/main/java/com/example/tomyongji/receipt/controller/ReceiptController.java
@@ -1,6 +1,7 @@
 package com.example.tomyongji.receipt.controller;
 
 import com.example.tomyongji.admin.dto.ApiResponse;
+import com.example.tomyongji.auth.service.CustomUserDetails;
 import com.example.tomyongji.receipt.dto.ReceiptByStudentClubDto;
 import com.example.tomyongji.receipt.dto.ReceiptCreateDto;
 import com.example.tomyongji.receipt.dto.ReceiptDto;
@@ -73,13 +74,19 @@ public class ReceiptController {
     }
 
 
+//    @Operation(summary = "영수증 삭제 api", description = "영수증 아이디를 통해 특정 영수증을 삭제합니다.")
+//    @DeleteMapping("/{receiptId}") //특정 영수증 삭제
+//    public ApiResponse<ReceiptDto> deleteReceipt(@PathVariable("receiptId") Long receiptId, @AuthenticationPrincipal CustomUserDetails currentUser) {
+//        ReceiptDto receipt = receiptService.deleteReceipt(receiptId, currentUser);
+//        return new ApiResponse<>(200, "영수증을 성공적으로 삭제했습니다.", receipt);
+//    }
+
     @Operation(summary = "영수증 삭제 api", description = "영수증 아이디를 통해 특정 영수증을 삭제합니다.")
     @DeleteMapping("/{receiptId}") //특정 영수증 삭제
-    public ApiResponse<ReceiptDto> deleteReceipt(@PathVariable Long receiptId) {
+    public ApiResponse<ReceiptDto> deleteReceipt(@PathVariable("receiptId") Long receiptId) {
         ReceiptDto receipt = receiptService.deleteReceipt(receiptId);
         return new ApiResponse<>(200, "영수증을 성공적으로 삭제했습니다.", receipt);
     }
-
 
     @Operation(summary = "영수증 수정 api", description = "영수증 아이디를 통해 특정 영수증을 수정합니다.")
     @PatchMapping //특정 영수증 수정

--- a/src/main/java/com/example/tomyongji/receipt/service/ReceiptService.java
+++ b/src/main/java/com/example/tomyongji/receipt/service/ReceiptService.java
@@ -2,17 +2,18 @@ package com.example.tomyongji.receipt.service;
 
 import static com.example.tomyongji.validation.ErrorMsg.DUPLICATED_FLOW;
 import static com.example.tomyongji.validation.ErrorMsg.EMPTY_CONTENT;
-import static com.example.tomyongji.validation.ErrorMsg.EMPTY_MONEY;
 import static com.example.tomyongji.validation.ErrorMsg.NOT_FOUND_RECEIPT;
 import static com.example.tomyongji.validation.ErrorMsg.NOT_FOUND_STUDENT_CLUB;
 import static com.example.tomyongji.validation.ErrorMsg.NOT_FOUND_USER;
+import static com.example.tomyongji.validation.ErrorMsg.NO_AUTHORIZATION_BELONGING;
+import static com.example.tomyongji.validation.ErrorMsg.NO_AUTHORIZATION_USER;
 
 import com.example.tomyongji.auth.entity.User;
 import com.example.tomyongji.auth.repository.UserRepository;
+import com.example.tomyongji.auth.service.CustomUserDetails;
 import com.example.tomyongji.receipt.dto.ReceiptByStudentClubDto;
 import com.example.tomyongji.receipt.dto.ReceiptCreateDto;
 import com.example.tomyongji.receipt.dto.ReceiptDto;
-import com.example.tomyongji.receipt.dto.ReceiptUpdateDto;
 import com.example.tomyongji.receipt.entity.Receipt;
 import com.example.tomyongji.receipt.entity.StudentClub;
 import com.example.tomyongji.receipt.mapper.ReceiptMapper;
@@ -23,9 +24,7 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -101,6 +100,36 @@ public class ReceiptService {
 
         return receiptMapper.toReceiptDto(receipt);
     }
+//    public ReceiptDto deleteReceipt(Long receiptId, CustomUserDetails currentUser) {
+//        //접근 권한: 유저가 아닌 경우
+//        if (currentUser == null || currentUser.getUser() == null) {
+//            throw new CustomException(NO_AUTHORIZATION_USER, 400);
+//        }
+//        User user = currentUser.getUser();
+//        StudentClub userStudentClub = user.getStudentClub();
+//
+//        //영수증 조회 및 존재 여부 확인
+//        Receipt receipt = receiptRepository.findById(receiptId)
+//            .orElseThrow(() -> new CustomException(NOT_FOUND_RECEIPT, 400));
+//
+//        //접근 권한: 다른 학생회인 경우
+//        StudentClub studentClub = receipt.getStudentClub();
+//        if (studentClub != userStudentClub) {
+//            throw new CustomException(NO_AUTHORIZATION_BELONGING, 400);
+//        }
+//
+//        //영수증 삭제
+//        receiptRepository.delete(receipt);
+//
+//        //잔액 업데이트 (항상 deposit 또는 withdrawal 중 하나만 값이 존재)
+//        int balanceAdjustment = receipt.getDeposit() - receipt.getWithdrawal();
+//        studentClub.setBalance(studentClub.getBalance() - balanceAdjustment);
+//        studentClubRepository.save(studentClub);
+//
+//        //DTO 반환
+//        return receiptMapper.toReceiptDto(receipt);
+//    }
+
     public ReceiptDto deleteReceipt(Long receiptId) {
         //영수증 조회 및 존재 여부 확인
         Receipt receipt = receiptRepository.findById(receiptId)

--- a/src/main/java/com/example/tomyongji/validation/ErrorMsg.java
+++ b/src/main/java/com/example/tomyongji/validation/ErrorMsg.java
@@ -15,7 +15,10 @@ public class ErrorMsg {
     public static final String EMPTY_CONTENT = "학생회비 사용 내용을 작성해주세요.";
     public static final String EMPTY_MONEY = "입출금 내역을 작성해주세요.";
     public static final String DUPLICATED_FLOW = "입금과 출금 둘 중 하나만 적어주세요.";
-    public static final String NO_AUTHRORIZATION = "접근 권한이 없습니다";
+    public static final String NO_AUTHORIZATION_USER = "접근 권한이 없습니다"; //가입된 유저가 아닌 경우
+    public static final String NO_AUTHORIZATION_ROLE = "접근 권한이 없습니다"; //접근 가능한 ROLE이 아닌 경우
+    public static final String NO_AUTHORIZATION_BELONGING = "접근 권한이 없습니다"; //접근 가능한 소속이 아닌 경우
+
     public static final String ERROR_SEND_EMAIL = "이메일 전송 중 오류가 발생했습니다.";
 
 }

--- a/src/test/java/com/example/tomyongji/ReceiptServiceTest.java
+++ b/src/test/java/com/example/tomyongji/ReceiptServiceTest.java
@@ -5,6 +5,8 @@ import static com.example.tomyongji.validation.ErrorMsg.EMPTY_CONTENT;
 import static com.example.tomyongji.validation.ErrorMsg.NOT_FOUND_RECEIPT;
 import static com.example.tomyongji.validation.ErrorMsg.NOT_FOUND_STUDENT_CLUB;
 import static com.example.tomyongji.validation.ErrorMsg.NOT_FOUND_USER;
+import static com.example.tomyongji.validation.ErrorMsg.NO_AUTHORIZATION_BELONGING;
+import static com.example.tomyongji.validation.ErrorMsg.NO_AUTHORIZATION_USER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -13,6 +15,7 @@ import static org.mockito.Mockito.when;
 
 import com.example.tomyongji.auth.entity.User;
 import com.example.tomyongji.auth.repository.UserRepository;
+import com.example.tomyongji.auth.service.CustomUserDetails;
 import com.example.tomyongji.receipt.dto.ReceiptByStudentClubDto;
 import com.example.tomyongji.receipt.dto.ReceiptCreateDto;
 import com.example.tomyongji.receipt.dto.ReceiptDto;
@@ -327,6 +330,32 @@ public class ReceiptServiceTest {
         verify(receiptRepository).findById(wrongReceiptId);
     }
 
+//    @Test
+//    @DisplayName("특정 영수증 삭제 성공")
+//    void deleteReceipt_Success() {
+//        //Given
+//        Long receiptId = receipt.getId();
+//        ReceiptDto receiptDto = ReceiptDto.builder()
+//            .receiptId(receipt.getId())
+//            .date(receipt.getDate())
+//            .content(receipt.getContent())
+//            .deposit(receipt.getDeposit())
+//            .build();
+//        CustomUserDetails currentUser = new CustomUserDetails(user);
+//
+//        when(receiptRepository.findById(receiptId)).thenReturn(Optional.of(receipt));
+//        when(receiptMapper.toReceiptDto(receipt)).thenReturn(receiptDto);
+//        //When
+//        ReceiptDto result = receiptService.deleteReceipt(receiptId, currentUser);
+//        //Then
+//        assertNotNull(result);
+//        assertEquals(result, receiptDto);
+//        assertEquals(user, currentUser.getUser());
+//        verify(receiptRepository).findById(receiptId);
+//        verify(receiptRepository).delete(receipt);
+//        verify(studentClubRepository).save(studentClub);
+//        verify(receiptMapper).toReceiptDto(receipt);
+//    }
     @Test
     @DisplayName("특정 영수증 삭제 성공")
     void deleteReceipt_Success() {
@@ -352,8 +381,24 @@ public class ReceiptServiceTest {
         verify(receiptMapper).toReceiptDto(receipt);
     }
 
+//    @Test
+//    @DisplayName("영수증 조회 실패로 인한 특정 영수증 삭제 실패")
+//    void deleteReceipt_NotFoundReceipt() {
+//        //Given
+//        Long wrongReceiptId = 999L;
+//        CustomUserDetails currentUser = new CustomUserDetails(user);
+//
+//        when(receiptRepository.findById(wrongReceiptId)).thenReturn(Optional.empty());
+//        //When
+//        CustomException exception = assertThrows(CustomException.class,
+//            () -> receiptService.deleteReceipt(wrongReceiptId, currentUser));
+//        //Then
+//        assertEquals(400, exception.getErrorCode());
+//        assertEquals(NOT_FOUND_RECEIPT, exception.getMessage());
+//        verify(receiptRepository).findById(wrongReceiptId);
+//    }
     @Test
-    @DisplayName("영수증 조회 실패로 인한 특정 영수증 삭제 성공")
+    @DisplayName("영수증 조회 실패로 인한 특정 영수증 삭제 실패")
     void deleteReceipt_NotFoundReceipt() {
         //Given
         Long wrongReceiptId = 999L;
@@ -367,6 +412,55 @@ public class ReceiptServiceTest {
         assertEquals(NOT_FOUND_RECEIPT, exception.getMessage());
         verify(receiptRepository).findById(wrongReceiptId);
     }
+
+//    @Test
+//    @DisplayName("미가입 유저의 접근으로 인한 특정 영수증 삭제 실패")
+//    void deleteReceipt_NoAuthorizationUser() {
+//        //Given
+//        Long receiptId = receipt.getId();
+//        CustomUserDetails currentUser = new CustomUserDetails(null);
+//
+//        //When
+//        CustomException exception = assertThrows(CustomException.class,
+//            () -> receiptService.deleteReceipt(receiptId, currentUser));
+//        //Then
+//        assertEquals(400, exception.getErrorCode());
+//        assertEquals(NO_AUTHORIZATION_USER, exception.getMessage());
+//    }
+//
+//    @Test
+//    @DisplayName("타소속의 접근으로 인한 특정 영수증 삭제 실패")
+//    void deleteReceipt_NoAuthorizationBelonging() {
+//        //Given
+//        Long receiptId = receipt.getId();
+//        StudentClub business = StudentClub.builder()
+//            .id(4L)
+//            .studentClubName("경영학과")
+//            .Balance(1000)
+//            .build();
+//        User user2 = User.builder()
+//            .id(2L)
+//            .userId("testUser2")
+//            .name("test name2")
+//            .studentNum("60000001")
+//            .collegeName("경영학부")
+//            .email("test2@example.com")
+//            .password("password123")
+//            .role("USER")
+//            .studentClub(business)
+//            .build();
+//        CustomUserDetails currentUser = new CustomUserDetails(user2);
+//
+//
+//        when(receiptRepository.findById(receiptId)).thenReturn(Optional.of(receipt));
+//        //When
+//        CustomException exception = assertThrows(CustomException.class,
+//            () -> receiptService.deleteReceipt(receiptId, currentUser));
+//        //Then
+//        assertEquals(400, exception.getErrorCode());
+//        assertEquals(NO_AUTHORIZATION_BELONGING, exception.getMessage());
+//        verify(receiptRepository).findById(receiptId);
+//    }
 
     @Test
     @DisplayName("영수증 수정 성공")


### PR DESCRIPTION
# 🫧투명지 PR🫧

### #️⃣연관된 이슈


### 📝작업 내용

회원가입한 유저의 Member 정보가 삭제되지 않는 오류를 수정함. 서비스 클래스의 멤버 삭제 메서드에 트랜잭션 어노테이션을 추가. 유저 삭제 전에 이와 연결된 소속 인증 정보와 메일 정보를 먼저 삭제 후 유저를 삭제하는 방식을 사용하여 해결
+ ErrorMsg에 유저 정보, 역할, 소속과 관련된 NO_AUTHORIZATION 메세지를 추가
영수증 삭제 메서드에만 유저와 소속 검증 로직을 추가 후 주석화

### 🔨테스트 결과 > 스크린샷 (선택)

> 테스트 결과나 스크린 샷으로 보여줘야하는 부분을 삽입해주세요,
### 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

