### PR TITLE
deleteMember 로직 수정

### DIFF
--- a/src/main/java/com/example/tomyongji/admin/service/AdminService.java
+++ b/src/main/java/com/example/tomyongji/admin/service/AdminService.java
@@ -130,13 +130,14 @@ public class AdminService {
 
         MemberDto memberDto = adminMapper.toMemberDto(member); //삭제된 멤버정보 반환을 위한 저장
 
+        if (!clubVerificationRepository.findByStudentNum(member.getStudentNum()).isEmpty()) {
+            clubVerificationRepository.deleteByStudentNum(member.getStudentNum());
+        }
         //멤버 등록을 해도 유저가 없을 수 있음
         Optional<User> user = Optional.ofNullable(
             userRepository.findByStudentNum(member.getStudentNum()));
-
         //유저가 있다면 유저의 메일과 유저를 삭제
         if (user.isPresent()) {
-            clubVerificationRepository.deleteByStudentNum(user.get().getStudentNum());
             emailVerificationRepository.deleteByEmail(user.get().getEmail());
             userRepository.delete(user.get());
         }

--- a/src/main/java/com/example/tomyongji/my/service/MyService.java
+++ b/src/main/java/com/example/tomyongji/my/service/MyService.java
@@ -87,15 +87,16 @@ public class MyService {
         Member member = memberRepository.findByStudentNum(deletedStudentNum)
             .orElseThrow(() -> new CustomException(NOT_FOUND_MEMBER, 400));
 
-
         MemberDto memberDto = myMapper.toMemberDto(member); //삭제된 멤버 정보를 보여주기 위한 반환값
 
+        if (!clubVerificationRepository.findByStudentNum(deletedStudentNum).isEmpty()) {
+            clubVerificationRepository.deleteByStudentNum(deletedStudentNum);
+        }
         //멤버 등록을 해도 유저가 없을 수 있음
         Optional<User> user = Optional.ofNullable(
             userRepository.findByStudentNum(deletedStudentNum));
         //유저가 있다면 유저의 메일과 유저를 삭제
         if (user.isPresent()) {
-            clubVerificationRepository.deleteByStudentNum(user.get().getStudentNum());
             emailVerificationRepository.deleteByEmail(user.get().getEmail());
             userRepository.delete(user.get());
         }


### PR DESCRIPTION
# 🫧투명지 PR🫧

### #️⃣연관된 이슈



### 📝작업 내용

소속인증을 마친 후 가입을 하지 않으면 소속인증 정보는 남지만 유저는 생성되지 않음.
즉, 기존 로직으로는 멤버를 삭제할 때 유저가 있으면 유저의 소속인증 정보, 메일정보, 유저를 삭제했지만
수정 후에는 유저가 없고 멤버 정보만 있어도 학번으로 소속인증 정보를 얻어내어 삭제.

### 🔨테스트 결과 > 스크린샷 (선택)

> 테스트 결과나 스크린 샷으로 보여줘야하는 부분을 삽입해주세요,
### 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

