### PR TITLE
학생회 Verification 타입 처리 통일

### DIFF
--- a/src/main/java/com/example/tomyongji/receipt/repository/StudentClubRepository.java
+++ b/src/main/java/com/example/tomyongji/receipt/repository/StudentClubRepository.java
@@ -27,4 +27,8 @@ public interface StudentClubRepository extends JpaRepository<StudentClub, Long> 
     @Modifying
     @Query("UPDATE StudentClub s SET s.verification = true WHERE s.id = :clubId")
     void updateVerificationById(@Param("clubId") Long clubId);
+
+    @Modifying
+    @Query("UPDATE StudentClub s SET s.verification = false WHERE s.id = :clubId")
+    void updateVerificationToFalseById(@Param("clubId") Long clubId);
 }

--- a/src/main/java/com/example/tomyongji/receipt/service/BreakDownService.java
+++ b/src/main/java/com/example/tomyongji/receipt/service/BreakDownService.java
@@ -49,6 +49,7 @@ public class BreakDownService {
     private final ReceiptRepository receiptRepository;
     private final StudentClubRepository studentClubRepository;
     private final ReceiptMapper mapper;
+    private final ReceiptService receiptService;
 
     public BreakDownDto parsePdf(MultipartFile file,
         String userId,
@@ -145,10 +146,7 @@ public class BreakDownService {
         receiptRepository.saveAll(receipts);
         studentClubRepository.save(club);
 
-        double verificationRatio = (double) receiptRepository.countByStudentClubAndVerificationTrue(club)/receiptRepository.countByStudentClub(club);
-        if(verificationRatio > 0.3){
-            studentClubRepository.updateVerificationById(clubId);
-        }
+        receiptService.checkAndUpdateVerificationStatus(clubId);
 
         return receipts.stream()
                 .map(mapper :: toReceiptDto)

--- a/src/main/java/com/example/tomyongji/receipt/service/CSVService.java
+++ b/src/main/java/com/example/tomyongji/receipt/service/CSVService.java
@@ -41,6 +41,7 @@ import java.util.logging.Logger;
 public class CSVService {
     private final ReceiptRepository receiptRepository;
     private final UserRepository userRepository;
+    private final ReceiptService receiptService;
     private static final Logger LOGGER = Logger.getLogger(ReceiptService.class.getName());
 
     @Transactional
@@ -93,6 +94,8 @@ public class CSVService {
         } catch (IOException | CsvValidationException e) {
             LOGGER.log(Level.SEVERE, "Error reading CSV file", e);
         }
+        
+        receiptService.checkAndUpdateVerificationStatus(studentClub.getId());
         return receipts;
     }
 

--- a/src/main/java/com/example/tomyongji/receipt/service/OCRService.java
+++ b/src/main/java/com/example/tomyongji/receipt/service/OCRService.java
@@ -79,6 +79,8 @@ public class OCRService {
         ReceiptCreateDto createDto = receiptMapper.toReceiptCreateDto(receiptDto);
         createDto.setUserId(userId);
         receiptService.createReceipt(createDto, currentUser);
+        
+        receiptService.checkAndUpdateVerificationStatus(user.getStudentClub().getId());
     }
 
     /**


### PR DESCRIPTION
# 🫧투명지 PR🫧

### #️⃣연관된 이슈

> #249 

### 📝작업 내용

> 기존 BreakDownService에서만 Verification 상태 변경 메서드를 Receipt 서비스로 이동
BreakDownService에서 뿐만 아니라, OCR, CSV 로 영수증 생성 삭제 시에도 verfication 필드 변경하도록 수정
30% 이상일 경우 뱃지 부여, 생성 및 삭제로 인해 30% 미만일 경우 다시 필드를 false로 돌려 뱃지 회수