### PR TITLE
회원탈퇴 로직 추가

### DIFF
--- a/src/main/java/com/example/tomyongji/admin/service/AdminService.java
+++ b/src/main/java/com/example/tomyongji/admin/service/AdminService.java
@@ -1,9 +1,5 @@
 package com.example.tomyongji.admin.service;
 
-import static com.example.tomyongji.validation.ErrorMsg.EXISTING_USER;
-import static com.example.tomyongji.validation.ErrorMsg.NOT_FOUND_MEMBER;
-import static com.example.tomyongji.validation.ErrorMsg.NOT_FOUND_STUDENT_CLUB;
-
 import com.example.tomyongji.admin.dto.MemberDto;
 import com.example.tomyongji.admin.dto.PresidentDto;
 import com.example.tomyongji.admin.entity.Member;
@@ -28,6 +24,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import static com.example.tomyongji.validation.ErrorMsg.*;
+
 @Service
 @RequiredArgsConstructor
 public class AdminService {
@@ -49,6 +47,9 @@ public class AdminService {
             throw new CustomException(NOT_FOUND_STUDENT_CLUB, 400);
         }
         President president = studentClub.get().getPresident();
+        if (president == null) {
+            throw new CustomException(NOT_FOUND_PRESIDENT, 400);
+        }
         PresidentDto presidentDto = adminMapper.toPresidentDto(president);
         presidentDto.setClubId(clubId);
         return presidentDto;

--- a/src/main/java/com/example/tomyongji/auth/controller/UserController.java
+++ b/src/main/java/com/example/tomyongji/auth/controller/UserController.java
@@ -57,11 +57,5 @@ public class UserController {
         return new ApiResponse(200,"소속인증을 성공적으로 마쳤습니다.",isClubVerify);
     }
 
-    @Operation(summary = "회원탈퇴 API", description = "사용자가 회원탈퇴를 합니다.")
-    @DeleteMapping("/delete")
-    public ApiResponse<String> deleteUser(@AuthenticationPrincipal UserDetails currentUser) {
-        String userId = currentUser.getUsername();
-        userService.deleteUser(userId);
-        return new ApiResponse<>(200, "회원탈퇴가 완료되었습니다.", "탈퇴 완료");
-    }
+
 }

--- a/src/main/java/com/example/tomyongji/auth/controller/UserController.java
+++ b/src/main/java/com/example/tomyongji/auth/controller/UserController.java
@@ -57,5 +57,12 @@ public class UserController {
         return new ApiResponse(200,"소속인증을 성공적으로 마쳤습니다.",isClubVerify);
     }
 
+    @Operation(summary = "회원탈퇴 API", description = "사용자가 회원탈퇴를 합니다.")
+    @DeleteMapping("/delete")
+    public ApiResponse<Void> deleteUser(@AuthenticationPrincipal UserDetails currentUser) {
+        String userId = currentUser.getUsername();
+        userService.deleteUser(userId);
+        return new ApiResponse<>(200, "회원탈퇴가 완료되었습니다.");
+    }
 
 }

--- a/src/main/java/com/example/tomyongji/auth/controller/UserController.java
+++ b/src/main/java/com/example/tomyongji/auth/controller/UserController.java
@@ -12,6 +12,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name="로그인, 회원가입 api", description = "로그인, 회원가입에 관련된 api입니다.")
@@ -53,5 +55,13 @@ public class UserController {
     public ApiResponse<Boolean> VerifyClub(@RequestBody ClubVerifyRequestDto clubVerifyDto) {
         boolean isClubVerify = userService.verifyClub(clubVerifyDto);
         return new ApiResponse(200,"소속인증을 성공적으로 마쳤습니다.",isClubVerify);
+    }
+
+    @Operation(summary = "회원탈퇴 API", description = "사용자가 회원탈퇴를 합니다.")
+    @DeleteMapping("/delete")
+    public ApiResponse<String> deleteUser(@AuthenticationPrincipal UserDetails currentUser) {
+        String userId = currentUser.getUsername();
+        userService.deleteUser(userId);
+        return new ApiResponse<>(200, "회원탈퇴가 완료되었습니다.", "탈퇴 완료");
     }
 }

--- a/src/main/java/com/example/tomyongji/auth/service/UserService.java
+++ b/src/main/java/com/example/tomyongji/auth/service/UserService.java
@@ -17,4 +17,6 @@ public interface UserService {
 
     Boolean verifyClub(ClubVerifyRequestDto clubVerifyRequestDto);
 
+    public void deleteUser(String userId);
+
 }

--- a/src/main/java/com/example/tomyongji/auth/service/UserServiceImpl.java
+++ b/src/main/java/com/example/tomyongji/auth/service/UserServiceImpl.java
@@ -165,6 +165,29 @@ public class UserServiceImpl implements UserService {
         }
     }
 
+    //회원 탈퇴
+    @Override
+    @Transactional
+    public void deleteUser(String userId){
+        User user = userRepository.findByUserId(userId)
+                .orElseThrow(() -> new CustomException(NOT_FOUND_USER, 400));
 
+        if ("PRESIDENT".equals(user.getRole())) {
+            throw new CustomException(NOT_DELETE_PRESIDENT, 400);
+        }
+
+        if (!clubVerificationRepository.findByStudentNum(user.getStudentNum()).isEmpty()) {
+            clubVerificationRepository.deleteByStudentNum(user.getStudentNum());
+        }
+
+        emailVerificationRepository.deleteByEmail(user.getEmail());
+
+        Optional<Member> member = memberInfoRepository.findByStudentNum(user.getStudentNum());
+        if (member.isPresent()) {
+            memberInfoRepository.delete(member.get());
+        }
+
+        userRepository.delete(user);
+    }
 
 }

--- a/src/main/java/com/example/tomyongji/auth/service/UserServiceImpl.java
+++ b/src/main/java/com/example/tomyongji/auth/service/UserServiceImpl.java
@@ -172,22 +172,40 @@ public class UserServiceImpl implements UserService {
         User user = userRepository.findByUserId(userId)
                 .orElseThrow(() -> new CustomException(NOT_FOUND_USER, 400));
 
-        if ("PRESIDENT".equals(user.getRole())) {
-            throw new CustomException(NOT_DELETE_PRESIDENT, 400);
-        }
-
         if (!clubVerificationRepository.findByStudentNum(user.getStudentNum()).isEmpty()) {
             clubVerificationRepository.deleteByStudentNum(user.getStudentNum());
         }
 
         emailVerificationRepository.deleteByEmail(user.getEmail());
 
-        Optional<Member> member = memberInfoRepository.findByStudentNum(user.getStudentNum());
-        if (member.isPresent()) {
-            memberInfoRepository.delete(member.get());
+        //회장과 멤버 필드 지우기
+        String userRole = user.getRole();
+        if ("PRESIDENT".equals(userRole)) {
+            deletePresidentData(user.getStudentNum());
+        } else if ("STU".equals(userRole)) {
+            deleteMemberData(user.getStudentNum());
         }
 
         userRepository.delete(user);
     }
 
+    private void deletePresidentData(String studentNum) {
+        President president = presidentInfoRepository.findByStudentNum(studentNum);
+        if (president != null) {
+            //엔터티 참조 제약때문에 먼저 참조 제거
+            Optional<StudentClub> studentClub = studentClubRepository.findByPresident(president);
+            if (studentClub.isPresent()) {
+                studentClub.get().setPresident(null);
+                studentClubRepository.save(studentClub.get());
+            }
+            presidentInfoRepository.delete(president);
+        }
+    }
+
+    private void deleteMemberData(String studentNum) {
+        Optional<Member> member = memberInfoRepository.findByStudentNum(studentNum);
+        if (member.isPresent()) {
+            memberInfoRepository.delete(member.get());
+        }
+    }
 }

--- a/src/main/java/com/example/tomyongji/auth/service/UserServiceImpl.java
+++ b/src/main/java/com/example/tomyongji/auth/service/UserServiceImpl.java
@@ -151,6 +151,9 @@ public class UserServiceImpl implements UserService {
             return true;
         }else if(clubVerifyRequestDto.getRole().equals("PRESIDENT")){
             President president = this.presidentInfoRepository.findByStudentNum(clubVerifyRequestDto.getStudentNum());
+            if (president == null) {
+                throw new CustomException(NOT_FOUND_PRESIDENT, 400);
+            }
             StudentClub userClub = studentClubRepository.findByPresident(president)
                     .orElseThrow(()-> new CustomException(NOT_FOUND_STUDENT_CLUB,400));
             ClubVerification clubVerification = ClubVerification.builder()

--- a/src/main/java/com/example/tomyongji/validation/ErrorMsg.java
+++ b/src/main/java/com/example/tomyongji/validation/ErrorMsg.java
@@ -29,4 +29,6 @@ public class ErrorMsg {
     public static final String NOT_FOUND_BREAKDOWN = "거래내역서를 찾을 수 없습니다.";
     public static final String AUTENTICITY_FAILURE = "진위확인에 실패했습니다.";
     public static final String EXTERNAL_SERVER_ERROR = "외부 서버의 오류가 발생했습니다.";
+    public static final String NOT_DELETE_PRESIDENT = "회장은 탈퇴할 수 없습니다. 먼저 회장직을 넘겨주세요.";
+
 }

--- a/src/main/java/com/example/tomyongji/validation/ErrorMsg.java
+++ b/src/main/java/com/example/tomyongji/validation/ErrorMsg.java
@@ -29,6 +29,5 @@ public class ErrorMsg {
     public static final String NOT_FOUND_BREAKDOWN = "거래내역서를 찾을 수 없습니다.";
     public static final String AUTENTICITY_FAILURE = "진위확인에 실패했습니다.";
     public static final String EXTERNAL_SERVER_ERROR = "외부 서버의 오류가 발생했습니다.";
-    public static final String NOT_DELETE_PRESIDENT = "회장은 탈퇴할 수 없습니다. 먼저 회장직을 넘겨주세요.";
 
 }


### PR DESCRIPTION
# 🫧투명지 PR🫧

#252 

### 📝작업 내용

- 로그인 한 유저의 회원 탈퇴 처리 -> 로그인된 유저의 권한 확인, 권환 확인 후 학번을 바탕으로 해당 권한에 맞는 엔터티의 레코드 삭제
ex) president의 경우 president 레코드 삭제
- 영수증은 해당 학생회의 유저, 멤버가 탈퇴하더라고, 학생회가 사라지지 않는 한 삭제 되지 않음. 별개의 관계를 맺고 있음.
- JWT를 사용하여 현재 로그인 한 유저의 탈퇴가 이루어짐.
- 추가로, 회장의 부재일 때 발생할 수 있는 Null 에러 처리 추가


### 🔨테스트 결과 > 스크린샷 (선택)
- 탈퇴 전 유저 생성
<img width="1379" height="298" alt="스크린샷 2025-09-20 173207" src="https://github.com/user-attachments/assets/ef77b271-43b3-4441-95cd-ed7243f43936" />
- 탈퇴 후 DB에서 유저 삭제
<img width="1480" height="502" alt="스크린샷 2025-09-20 180807" src="https://github.com/user-attachments/assets/65852f21-1d94-4510-8bfe-b702352c68ac" />

### 💬리뷰 요구사항(선택)


