### PR TITLE
Fix : 토스뱅크 키워드 에러 문제 해결

### DIFF
--- a/src/main/java/com/example/tomyongji/receipt/controller/BreakDownController.java
+++ b/src/main/java/com/example/tomyongji/receipt/controller/BreakDownController.java
@@ -29,7 +29,7 @@ public class BreakDownController {
     public ApiResponse<List<ReceiptDto>> parsePdfFile(
             @RequestPart("file") MultipartFile file,
             @RequestPart("userId") String userId,
-            @RequestPart("keyword") String keyword,
+            @RequestPart(value = "keyword", required = false) String keyword,
             @AuthenticationPrincipal UserDetails currentUser) throws Exception {
 
         BreakDownDto breakDownDto = breakDownService.parsePdf(file, userId, keyword, currentUser);


### PR DESCRIPTION
# 🫧투명지 PR🫧

### #️⃣연관된 이슈

> #289 

### 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

 수정전 : @RequestPart("keyword")
컨트롤러에서 사용한 @RequestPart는 기본적으로 Required = true 로 설정되어 있음.
이는 반드시 클라이언트가 keyword를 필수로 요청에 포함해야함을 나타내는 설정
따라서 keyword를 넣지 않았을 때는 issue의 사진과 같이 500 에러가 발생하게 됨.
키워드에 공백을 넣거나, 정상적으로 키워드를 포함하였을 때는 정상 작동함.
<img width="1357" height="535" alt="스크린샷 2025-11-27 203214" src="https://github.com/user-attachments/assets/83d07cb4-85e6-4fd4-b924-24ba8115ccb0" />

수정 후 : @RequestPart(value = "keyword", required = false)
클라이언트의 요청에 키워드를 필수로 포함해야한다는 설정을 false로 변경함으로써 공백, null 이 아니라 아무 값을 포함하지 않아도 동작하도록 파라미터 변경
파라미터 설정 변경 후 키워드를 포함하지 않아도 정상적으로 처리됨을 확인
<img width="1483" height="819" alt="스크린샷 2025-11-27 203341" src="https://github.com/user-attachments/assets/d2484990-60f5-4244-b35b-e1a8d1569941" />


### 🔨테스트 결과 > 스크린샷 (선택)

> 테스트 결과나 스크린 샷으로 보여줘야하는 부분을 삽입해주세요,
### 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

