### PR TITLE
fix(387): 소속원 추가 시 공백제거

### DIFF
--- a/src/main/java/com/example/tomyongji/domain/my/service/MyService.java
+++ b/src/main/java/com/example/tomyongji/domain/my/service/MyService.java
@@ -77,6 +77,7 @@ public class MyService {
     }
 
     public void saveMember(SaveMemberDto memberDto, UserDetails currentUser) {
+        memberDto.setStudentNum(memberDto.getStudentNum().trim());
         User user = userRepository.findById(memberDto.getId())
             .orElseThrow(() -> new CustomException(NOT_FOUND_USER, 400));
         checkMismatchedUser(user, currentUser);

--- a/src/test/java/com/example/tomyongji/my/MyServiceTest.java
+++ b/src/test/java/com/example/tomyongji/my/MyServiceTest.java
@@ -471,6 +471,35 @@ class MyServiceTest {
         }
 
         @Nested
+        @DisplayName("공백이 포함된 학번이 주어지면")
+        class Context_with_whitespace_student_num {
+
+            @Test
+            @DisplayName("학번을 trim 처리하여 저장한다")
+            void it_trims_student_num_and_saves_member() {
+                // given
+                SaveMemberDto dtoWithWhitespace = SaveMemberDto.builder()
+                        .id(user.getId())
+                        .studentNum("  60000001  ")
+                        .name("test name")
+                        .build();
+
+                doReturn(Optional.of(user)).when(userRepository).findById(dtoWithWhitespace.getId());
+                doReturn(Optional.of(user)).when(userRepository).findByUserId(currentUser.getUsername());
+                doReturn(false).when(memberRepository).existsByStudentNum("60000001");
+                doReturn(member).when(myMapper).toMemberEntity(dtoWithWhitespace);
+
+                // when
+                myService.saveMember(dtoWithWhitespace, currentUser);
+
+                // then
+                assertThat(dtoWithWhitespace.getStudentNum()).isEqualTo("60000001");
+                then(memberRepository).should().existsByStudentNum("60000001");
+                then(memberRepository).should().save(member);
+            }
+        }
+
+        @Nested
         @DisplayName("존재하지 않는 사용자 ID가 주어지면")
         class Context_with_nonexistent_user_id {
 


### PR DESCRIPTION
# 🫧투명지 PR🫧

### #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#387 

### 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 문제상황
학생회 멤버 추가시 공백이 입력되어 학생회 소속인증을 못하는 문제 발생

### 해결 방안
Myservice 클래스 내 saveMember 메서드 학번 입력시 trim을 통한 공백 제거

- 서비스 코드 수정
- 테스트 코드 추가


### 🔨테스트 결과 > 스크린샷 (선택)

> 테스트 결과나 스크린 샷으로 보여줘야하는 부분을 삽입해주세요,
### 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

