### PR TITLE
feat(402): EasyExcel 영수증 엑셀 다운로드 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -113,6 +113,9 @@ dependencies {
 	// redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+	// EasyExcel
+	implementation 'com.alibaba:easyexcel:3.3.4'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/tomyongji/config/SecurityConfig.java
+++ b/src/main/java/com/example/tomyongji/config/SecurityConfig.java
@@ -41,6 +41,7 @@ public class SecurityConfig {
                         .requestMatchers("/actuator/health", "/actuator/prometheus").permitAll()
                         // 해당 API에 대해서는 모든 요청을 허가
                         .requestMatchers("/api/users/**","/swagger-ui/**", "/v3/api-docs/**","/api/csv/**","/api/club/**","/api/collegesAndClubs").permitAll()
+                        .requestMatchers("/api/excel/**").hasAnyRole("STU","PRESIDENT")
                         .requestMatchers("/api/password/**").permitAll()
                         .requestMatchers(HttpMethod.GET,"/api/receipt").permitAll()
                         .requestMatchers(HttpMethod.POST,"/api/receipt").hasAnyRole("STU","PRESIDENT","ADMIN")

--- a/src/main/java/com/example/tomyongji/domain/receipt/controller/ExcelController.java
+++ b/src/main/java/com/example/tomyongji/domain/receipt/controller/ExcelController.java
@@ -1,0 +1,34 @@
+package com.example.tomyongji.domain.receipt.controller;
+
+import com.example.tomyongji.domain.receipt.dto.ExcelExportDto;
+import com.example.tomyongji.domain.receipt.service.ExcelService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "excel api", description = "엑셀 파일로 영수증 데이터를 내보냅니다.")
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/excel")
+public class ExcelController {
+
+    private final ExcelService excelService;
+
+    @Operation(summary = "Excel 내보내기 api", description = "영수증 데이터를 Excel 파일로 내보냅니다.")
+    @PostMapping("/export")
+    public void exportExcel(
+            @RequestBody ExcelExportDto excelExportDto,
+            HttpServletResponse response,
+            @AuthenticationPrincipal UserDetails currentUser) {
+        excelService.writeExcel(response, excelExportDto, currentUser);
+    }
+}

--- a/src/main/java/com/example/tomyongji/domain/receipt/dto/ExcelExportDto.java
+++ b/src/main/java/com/example/tomyongji/domain/receipt/dto/ExcelExportDto.java
@@ -1,0 +1,16 @@
+package com.example.tomyongji.domain.receipt.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+@Builder
+public class ExcelExportDto {
+    private String userId;
+    private int year;
+    private int month;
+}

--- a/src/main/java/com/example/tomyongji/domain/receipt/service/ExcelService.java
+++ b/src/main/java/com/example/tomyongji/domain/receipt/service/ExcelService.java
@@ -1,0 +1,111 @@
+package com.example.tomyongji.domain.receipt.service;
+
+import static com.example.tomyongji.global.error.ErrorMsg.NOT_FOUND_USER;
+import static com.example.tomyongji.global.error.ErrorMsg.NO_AUTHORIZATION_BELONGING;
+
+import com.alibaba.excel.EasyExcel;
+import com.alibaba.excel.write.metadata.style.WriteCellStyle;
+import com.alibaba.excel.write.metadata.style.WriteFont;
+import com.alibaba.excel.write.style.HorizontalCellStyleStrategy;
+import com.example.tomyongji.domain.auth.entity.User;
+import com.example.tomyongji.domain.auth.repository.UserRepository;
+import com.example.tomyongji.domain.receipt.dto.ExcelExportDto;
+import com.example.tomyongji.domain.receipt.entity.Receipt;
+import com.example.tomyongji.domain.receipt.entity.StudentClub;
+import com.example.tomyongji.domain.receipt.repository.ReceiptRepository;
+import com.example.tomyongji.global.error.CustomException;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ExcelService {
+
+    private final ReceiptRepository receiptRepository;
+    private final UserRepository userRepository;
+
+    public void writeExcel(HttpServletResponse response, ExcelExportDto dto, UserDetails currentUser) {
+        String userId = dto.getUserId();
+        int year = dto.getYear();
+        int month = dto.getMonth();
+
+        StudentClub studentClub = userRepository.findByUserId(userId)
+                .orElseThrow(() -> new CustomException(NOT_FOUND_USER, 400))
+                .getStudentClub();
+
+        checkClub(studentClub, currentUser);
+
+        Calendar cal = Calendar.getInstance();
+        cal.set(year, month - 1, 1, 0, 0, 0);
+        cal.set(Calendar.MILLISECOND, 0);
+        Date startDate = cal.getTime();
+        cal.add(Calendar.MONTH, 1);
+        Date endDate = cal.getTime();
+
+        List<Receipt> receipts = receiptRepository.findByStudentClubAndDateBetween(studentClub, startDate, endDate);
+
+        try {
+            response.setContentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+            String fileName = "receipts_" + studentClub.getStudentClubName() + "_" + year + "_" + month + ".xlsx";
+            String encodedFileName = URLEncoder.encode(fileName, StandardCharsets.UTF_8).replaceAll("\\+", "%20");
+            response.setHeader("Content-Disposition", "attachment; filename*=UTF-8''" + encodedFileName);
+
+            List<List<String>> head = Arrays.asList(
+                    Arrays.asList("date"),
+                    Arrays.asList("content"),
+                    Arrays.asList("deposit"),
+                    Arrays.asList("withdrawal")
+            );
+
+            SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
+            List<List<Object>> data = new ArrayList<>();
+            for (Receipt receipt : receipts) {
+                data.add(Arrays.<Object>asList(
+                        sdf.format(receipt.getDate()),
+                        receipt.getContent(),
+                        receipt.getDeposit(),
+                        receipt.getWithdrawal()
+                ));
+            }
+
+            WriteFont font = new WriteFont();
+            font.setFontName("맑은 고딕");
+
+            WriteCellStyle headStyle = new WriteCellStyle();
+            headStyle.setWriteFont(font);
+
+            WriteCellStyle contentStyle = new WriteCellStyle();
+            contentStyle.setWriteFont(font);
+
+            EasyExcel.write(response.getOutputStream())
+                    .head(head)
+                    .registerWriteHandler(new HorizontalCellStyleStrategy(headStyle, contentStyle))
+                    .autoCloseStream(false)
+                    .sheet("영수증")
+                    .doWrite(data);
+
+        } catch (IOException e) {
+            throw new RuntimeException("Excel export 실패", e);
+        }
+    }
+
+    private void checkClub(StudentClub studentClub, UserDetails currentUser) {
+        User compareUser = userRepository.findByUserId(currentUser.getUsername())
+                .orElseThrow(() -> new CustomException(NOT_FOUND_USER, 400));
+        if (!studentClub.equals(compareUser.getStudentClub())) {
+            throw new CustomException(NO_AUTHORIZATION_BELONGING, 400);
+        }
+    }
+
+}

--- a/src/test/java/com/example/tomyongji/receipt/ExcelServiceTest.java
+++ b/src/test/java/com/example/tomyongji/receipt/ExcelServiceTest.java
@@ -1,0 +1,255 @@
+package com.example.tomyongji.receipt;
+
+import static com.example.tomyongji.global.error.ErrorMsg.NO_AUTHORIZATION_BELONGING;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import com.example.tomyongji.domain.auth.entity.User;
+import com.example.tomyongji.domain.auth.repository.UserRepository;
+import com.example.tomyongji.domain.receipt.dto.ExcelExportDto;
+import com.example.tomyongji.domain.receipt.entity.Receipt;
+import com.example.tomyongji.domain.receipt.entity.StudentClub;
+import com.example.tomyongji.domain.receipt.repository.ReceiptRepository;
+import com.example.tomyongji.domain.receipt.service.ExcelService;
+import com.example.tomyongji.global.error.CustomException;
+
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.WriteListener;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.test.context.ActiveProfiles;
+
+@ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
+class ExcelServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private ReceiptRepository receiptRepository;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @InjectMocks
+    private ExcelService excelService;
+
+    private User user;
+    private User anotherUser;
+    private StudentClub studentClub;
+    private StudentClub anotherStudentClub;
+    private UserDetails currentUser;
+    private UserDetails anotherCurrentUser;
+
+    @BeforeEach
+    void setUp() {
+        studentClub = createStudentClub(30L, "스마트시스템공과대학 학생회", 100000);
+        anotherStudentClub = createStudentClub(35L, "아너칼리지(자연)", 50000);
+
+        user = createUser(
+                1L,
+                "testUser",
+                "테스트유저",
+                "60221317",
+                studentClub,
+                "스마트시스템공과대학",
+                "test@example.com",
+                "password123!",
+                "PRESIDENT"
+        );
+
+        anotherUser = createUser(
+                2L,
+                "anotherUser",
+                "다른유저",
+                "60000001",
+                anotherStudentClub,
+                "아너칼리지",
+                "another@example.com",
+                "password123!",
+                "PRESIDENT"
+        );
+
+        currentUser = createUserDetails("testUser", "password123!");
+        anotherCurrentUser = createUserDetails("anotherUser", "password123!");
+    }
+
+    private StudentClub createStudentClub(Long id, String name, Integer balance) {
+        return StudentClub.builder()
+                .id(id)
+                .studentClubName(name)
+                .Balance(balance)
+                .build();
+    }
+
+    private User createUser(Long id, String userId, String name, String studentNum,
+                            StudentClub studentClub, String collegeName, String email,
+                            String password, String role) {
+        return User.builder()
+                .id(id)
+                .userId(userId)
+                .name(name)
+                .studentNum(studentNum)
+                .studentClub(studentClub)
+                .collegeName(collegeName)
+                .email(email)
+                .password(password)
+                .role(role)
+                .build();
+    }
+
+    private UserDetails createUserDetails(String username, String password) {
+        return org.springframework.security.core.userdetails.User.builder()
+                .username(username)
+                .password(password)
+                .authorities("ROLE_PRESIDENT")
+                .build();
+    }
+
+    private Receipt createReceipt(Date date, String content, int deposit, int withdrawal) {
+        return Receipt.builder()
+                .date(date)
+                .content(content)
+                .deposit(deposit)
+                .withdrawal(withdrawal)
+                .studentClub(studentClub)
+                .build();
+    }
+
+    /**
+     * ByteArrayOutputStream을 감싸는 ServletOutputStream 구현체.
+     * HttpServletResponse.getOutputStream() mock에서 실제 바이트 내용을 검증하기 위해 사용한다.
+     */
+    private static class ByteArrayServletOutputStream extends ServletOutputStream {
+        private final ByteArrayOutputStream buffer;
+
+        ByteArrayServletOutputStream(ByteArrayOutputStream buffer) {
+            this.buffer = buffer;
+        }
+
+        @Override
+        public void write(int b) {
+            buffer.write(b);
+        }
+
+        @Override
+        public boolean isReady() {
+            return true;
+        }
+
+        @Override
+        public void setWriteListener(WriteListener writeListener) {
+        }
+
+        byte[] toByteArray() {
+            return buffer.toByteArray();
+        }
+    }
+
+    @Nested
+    @DisplayName("writeExcel 메서드는")
+    class Describe_writeExcel {
+
+        @Nested
+        @DisplayName("올바른 권한과 유저로 호출하면")
+        class Context_with_valid_user_and_permission {
+
+            @Test
+            @DisplayName("응답 헤더를 설정하고 엑셀 데이터를 OutputStream에 write한다")
+            void it_writes_excel_data_with_headers() throws IOException, ParseException {
+                // given
+                ExcelExportDto dto = ExcelExportDto.builder()
+                        .userId("testUser")
+                        .year(2024)
+                        .month(1)
+                        .build();
+
+                SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+                Receipt receipt1 = createReceipt(
+                        dateFormat.parse("2024-01-15"),
+                        "카페 결제",
+                        0,
+                        5000
+                );
+                Receipt receipt2 = createReceipt(
+                        dateFormat.parse("2024-01-16"),
+                        "입금",
+                        10000,
+                        0
+                );
+                List<Receipt> receipts = Arrays.asList(receipt1, receipt2);
+
+                given(userRepository.findByUserId("testUser")).willReturn(Optional.of(user));
+                given(userRepository.findByUserId(currentUser.getUsername())).willReturn(Optional.of(user));
+                given(receiptRepository.findByStudentClubAndDateBetween(
+                        eq(studentClub), any(Date.class), any(Date.class)))
+                        .willReturn(receipts);
+
+                ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+                ByteArrayServletOutputStream servletOutputStream =
+                        new ByteArrayServletOutputStream(byteArrayOutputStream);
+                given(response.getOutputStream()).willReturn(servletOutputStream);
+
+                // when
+                excelService.writeExcel(response, dto, currentUser);
+
+                // then
+                then(response).should().setContentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+                then(response).should().setHeader(eq("Content-Disposition"), anyString());
+                byte[] writtenBytes = servletOutputStream.toByteArray();
+                org.assertj.core.api.Assertions.assertThat(writtenBytes).isNotEmpty();
+            }
+        }
+
+        @Nested
+        @DisplayName("현재 로그인 유저의 학생회와 dto.userId의 학생회가 다른 경우")
+        class Context_with_unauthorized_user {
+
+            @Test
+            @DisplayName("NO_AUTHORIZATION_BELONGING CustomException을 발생시킨다")
+            void it_throws_no_authorization_exception() {
+                // given
+                ExcelExportDto dto = ExcelExportDto.builder()
+                        .userId("testUser")
+                        .year(2024)
+                        .month(1)
+                        .build();
+
+                given(userRepository.findByUserId("testUser")).willReturn(Optional.of(user));
+                given(userRepository.findByUserId(anotherCurrentUser.getUsername()))
+                        .willReturn(Optional.of(anotherUser));
+
+                // when & then
+                assertThatThrownBy(() -> excelService.writeExcel(response, dto, anotherCurrentUser))
+                        .isInstanceOf(CustomException.class)
+                        .hasFieldOrPropertyWithValue("errorCode", 400)
+                        .hasFieldOrPropertyWithValue("message", NO_AUTHORIZATION_BELONGING);
+
+                then(receiptRepository).should(org.mockito.Mockito.never())
+                        .findByStudentClubAndDateBetween(any(), any(Date.class), any(Date.class));
+            }
+        }
+    }
+}


### PR DESCRIPTION
# 🫧투명지 PR🫧

### #️⃣연관된 이슈

Closes #402

### 📝작업 내용

- `build.gradle`: `com.alibaba:easyexcel:3.3.4` 의존성 추가
- `ExcelExportDto.java` 생성 (`userId`, `year`, `month` 필드)
- `ExcelService.java` 구현
  - CSVService와 동일한 `checkClub()` 권한 검사 패턴 적용
  - EasyExcel Dynamic Write 방식 (`head` + `data` 리스트)으로 스트리밍 전송
  - Content-Type: `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`, UTF-8 인코딩 파일명
- `ExcelController.java`: `POST /api/excel/export` 엔드포인트, 반환형 `void`로 응답 중복 버그 해결
- `SecurityConfig.java`: `/api/excel/**` STU/PRESIDENT 역할로 접근 제한
- `ExcelServiceTest.java`: 성공 케이스 + 권한 불일치 CustomException 2건 통과

### 🔨테스트 결과 > 스크린샷 (선택)

- `ExcelServiceTest` 2건 통과
- `POST /api/excel/export` (2024년 3월) → 200 ✅, xlsx 5,934 bytes 정상 수신
- 서버 로그 `HttpMessageNotWritableException` 없음 확인

- 예시) 2024년 8월 영수증 내역 불러오기
<img width="367" height="527" alt="image" src="https://github.com/user-attachments/assets/adda7dc1-c0db-4ce5-b516-a2d740cdead1" />

### 💬리뷰 요구사항(선택)

> `ExcelController`에서 반환형을 `ResponseEntity<ApiResponse<Void>>` → `void`로 변경한 이유: `HttpServletResponse`에 직접 쓴 후 `ResponseEntity`를 반환하면 Spring이 xlsx Content-Type으로 ApiResponse 직렬화를 시도해 `HttpMessageNotWritableException`이 발생하므로, 응답을 직접 서블릿 응답에 쓰는 방식으로 통일했습니다.