### PR TITLE
feat(404): OCR 사용량 추적 구조화 로그 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,15 @@ out/
 ### VS Code ###
 .vscode/
 
+### Python ###
+__pycache__/
+*.py[cod]
+
+### OMC / Oh-My-Claude ###
+.omc/
+
 ### Claude Code ###
+.claude/skills/
 # 스킬, 레퍼런스 등 팀 공유 자산은 추적 (위 라인 제거)
 .claude/evidence/
 .claude/local-secrets.json

--- a/src/main/java/com/example/tomyongji/domain/receipt/controller/OCRController.java
+++ b/src/main/java/com/example/tomyongji/domain/receipt/controller/OCRController.java
@@ -6,6 +6,7 @@ import com.example.tomyongji.domain.receipt.service.OCRService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+@Slf4j
 @Tag(name = "OCR api", description = "영수증 이미지를 OCR로 스캔하여 업로드하는 API들입니다.")
 @RestController
 @RequiredArgsConstructor
@@ -32,6 +34,7 @@ public class OCRController {
     @PostMapping("/upload/{userId}")
     public ResponseEntity<ApiResponse<OCRResultDto>> uploadImageAndExtractText(@RequestPart("file") MultipartFile file, @PathVariable("userId") String userId, @AuthenticationPrincipal
     UserDetails currentUser) {
+        log.info("[OCR_USAGE] userId={} filename={} event=request", userId, file.getOriginalFilename());
         OCRResultDto result = ocrService.processImage(file);
         ocrService.uploadOcrReceipt(result, userId, currentUser);
         return ResponseEntity.status(HttpStatus.CREATED).body(

--- a/src/main/java/com/example/tomyongji/domain/receipt/service/OCRService.java
+++ b/src/main/java/com/example/tomyongji/domain/receipt/service/OCRService.java
@@ -57,12 +57,15 @@ public class OCRService {
             return sendOCRRequest(file);
         } catch (IOException e) {
             log.error("OCR I/O 에러", e);
+            log.warn("[OCR_USAGE] result=failure reason=io_error");
             throw new CustomException("OCR 요청 중 I/O 오류가 발생했습니다.", 500);
         } catch (ParseException e) {
             log.error("날짜 파싱 오류", e);
+            log.warn("[OCR_USAGE] result=failure reason=parse_error");
             throw new CustomException("OCR 응답 날짜 파싱에 실패했습니다.", 500);
         } catch (Exception e) {
             log.error("OCR 처리 오류", e);
+            log.warn("[OCR_USAGE] result=failure reason=unknown");
             throw new CustomException("OCR 처리 중 예외가 발생했습니다.", 500);
         }
     }
@@ -79,7 +82,7 @@ public class OCRService {
         ReceiptCreateDto createDto = receiptMapper.toReceiptCreateDto(receiptDto);
         createDto.setUserId(userId);
         receiptService.createReceipt(createDto, currentUser);
-        
+        log.info("[OCR_USAGE] userId={} clubId={} result=success", userId, user.getStudentClub().getId());
         receiptService.checkAndUpdateVerificationStatus(user.getStudentClub().getId());
     }
 

--- a/src/test/java/com/example/tomyongji/receipt/OCRControllerTest.java
+++ b/src/test/java/com/example/tomyongji/receipt/OCRControllerTest.java
@@ -1,0 +1,266 @@
+package com.example.tomyongji.receipt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.example.tomyongji.config.SecurityConfig;
+import com.example.tomyongji.domain.auth.jwt.JwtProvider;
+import com.example.tomyongji.domain.receipt.controller.OCRController;
+import com.example.tomyongji.domain.receipt.dto.OCRResultDto;
+import com.example.tomyongji.domain.receipt.service.OCRService;
+import java.util.Date;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(OCRController.class)
+@Import(SecurityConfig.class)
+@ActiveProfiles("test")
+class OCRControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private OCRService ocrService;
+
+    @MockBean
+    private JwtProvider jwtProvider;
+
+    private Logger controllerLogger;
+    private ListAppender<ILoggingEvent> listAppender;
+
+    @BeforeEach
+    void setUp() {
+        // OCRController 클래스의 로거를 캡처
+        controllerLogger = (Logger) LoggerFactory.getLogger(OCRController.class);
+        listAppender = new ListAppender<>();
+        listAppender.start();
+        controllerLogger.addAppender(listAppender);
+        controllerLogger.setLevel(Level.INFO);
+    }
+
+    @AfterEach
+    void tearDown() {
+        controllerLogger.detachAppender(listAppender);
+    }
+
+    @Nested
+    @DisplayName("uploadImageAndExtractText 메서드는")
+    class Describe_uploadImageAndExtractText {
+
+        @Nested
+        @DisplayName("인증된 사용자가 이미지 파일을 업로드하면")
+        class Context_with_authenticated_user_and_valid_file {
+
+            @Test
+            @WithMockUser(username = "testUser", roles = {"PRESIDENT"})
+            @DisplayName("진입 로그에 [OCR_USAGE] 태그가 포함된다")
+            void uploadImageAndExtractText_logsOcrUsageTag() throws Exception {
+                // given
+                String userId = "testUser";
+                String filename = "receipt.jpg";
+                MockMultipartFile file = new MockMultipartFile(
+                        "file", filename, "image/jpeg", "test-image-content".getBytes()
+                );
+                OCRResultDto resultDto = new OCRResultDto(new Date(), "테스트 상점", 5000);
+
+                given(ocrService.processImage(any())).willReturn(resultDto);
+                willDoNothing().given(ocrService).uploadOcrReceipt(any(), eq(userId), any(UserDetails.class));
+
+                // when
+                mockMvc.perform(multipart("/api/ocr/upload/{userId}", userId)
+                                .file(file))
+                        .andExpect(status().isCreated());
+
+                // then
+                boolean hasOcrUsageTag = listAppender.list.stream()
+                        .filter(event -> event.getLevel() == Level.INFO)
+                        .map(ILoggingEvent::getFormattedMessage)
+                        .anyMatch(msg -> msg.contains("[OCR_USAGE]"));
+
+                assertThat(hasOcrUsageTag)
+                        .as("uploadImageAndExtractText 진입 시 INFO 레벨로 [OCR_USAGE] 태그가 포함된 로그가 기록되어야 한다")
+                        .isTrue();
+            }
+
+            @Test
+            @WithMockUser(username = "testUser", roles = {"PRESIDENT"})
+            @DisplayName("진입 로그에 event=request 가 포함된다")
+            void uploadImageAndExtractText_logsEventRequest() throws Exception {
+                // given
+                String userId = "testUser";
+                String filename = "receipt.jpg";
+                MockMultipartFile file = new MockMultipartFile(
+                        "file", filename, "image/jpeg", "test-image-content".getBytes()
+                );
+                OCRResultDto resultDto = new OCRResultDto(new Date(), "테스트 상점", 5000);
+
+                given(ocrService.processImage(any())).willReturn(resultDto);
+                willDoNothing().given(ocrService).uploadOcrReceipt(any(), eq(userId), any(UserDetails.class));
+
+                // when
+                mockMvc.perform(multipart("/api/ocr/upload/{userId}", userId)
+                                .file(file))
+                        .andExpect(status().isCreated());
+
+                // then
+                boolean hasEventRequest = listAppender.list.stream()
+                        .filter(event -> event.getLevel() == Level.INFO)
+                        .map(ILoggingEvent::getFormattedMessage)
+                        .anyMatch(msg -> msg.contains("[OCR_USAGE]") && msg.contains("event=request"));
+
+                assertThat(hasEventRequest)
+                        .as("uploadImageAndExtractText 진입 로그에 event=request 가 포함되어야 한다")
+                        .isTrue();
+            }
+
+            @Test
+            @WithMockUser(username = "testUser", roles = {"PRESIDENT"})
+            @DisplayName("진입 로그에 userId 값이 포함된다")
+            void uploadImageAndExtractText_logsUserId() throws Exception {
+                // given
+                String userId = "testUser";
+                String filename = "receipt.jpg";
+                MockMultipartFile file = new MockMultipartFile(
+                        "file", filename, "image/jpeg", "test-image-content".getBytes()
+                );
+                OCRResultDto resultDto = new OCRResultDto(new Date(), "테스트 상점", 5000);
+
+                given(ocrService.processImage(any())).willReturn(resultDto);
+                willDoNothing().given(ocrService).uploadOcrReceipt(any(), eq(userId), any(UserDetails.class));
+
+                // when
+                mockMvc.perform(multipart("/api/ocr/upload/{userId}", userId)
+                                .file(file))
+                        .andExpect(status().isCreated());
+
+                // then
+                boolean hasUserId = listAppender.list.stream()
+                        .filter(event -> event.getLevel() == Level.INFO)
+                        .map(ILoggingEvent::getFormattedMessage)
+                        .anyMatch(msg -> msg.contains("[OCR_USAGE]") && msg.contains(userId));
+
+                assertThat(hasUserId)
+                        .as("uploadImageAndExtractText 진입 로그에 userId=" + userId + " 값이 포함되어야 한다")
+                        .isTrue();
+            }
+
+            @Test
+            @WithMockUser(username = "testUser", roles = {"PRESIDENT"})
+            @DisplayName("진입 로그에 filename 값이 포함된다")
+            void uploadImageAndExtractText_logsFilename() throws Exception {
+                // given
+                String userId = "testUser";
+                String filename = "receipt.jpg";
+                MockMultipartFile file = new MockMultipartFile(
+                        "file", filename, "image/jpeg", "test-image-content".getBytes()
+                );
+                OCRResultDto resultDto = new OCRResultDto(new Date(), "테스트 상점", 5000);
+
+                given(ocrService.processImage(any())).willReturn(resultDto);
+                willDoNothing().given(ocrService).uploadOcrReceipt(any(), eq(userId), any(UserDetails.class));
+
+                // when
+                mockMvc.perform(multipart("/api/ocr/upload/{userId}", userId)
+                                .file(file))
+                        .andExpect(status().isCreated());
+
+                // then
+                boolean hasFilename = listAppender.list.stream()
+                        .filter(event -> event.getLevel() == Level.INFO)
+                        .map(ILoggingEvent::getFormattedMessage)
+                        .anyMatch(msg -> msg.contains("[OCR_USAGE]") && msg.contains(filename));
+
+                assertThat(hasFilename)
+                        .as("uploadImageAndExtractText 진입 로그에 filename=" + filename + " 값이 포함되어야 한다")
+                        .isTrue();
+            }
+
+            @Test
+            @WithMockUser(username = "testUser", roles = {"PRESIDENT"})
+            @DisplayName("진입 로그는 processImage 호출 전에 기록된다 (로그가 존재해야 함)")
+            void uploadImageAndExtractText_logsBeforeProcessImage() throws Exception {
+                // given
+                String userId = "testUser";
+                String filename = "receipt.jpg";
+                MockMultipartFile file = new MockMultipartFile(
+                        "file", filename, "image/jpeg", "test-image-content".getBytes()
+                );
+                OCRResultDto resultDto = new OCRResultDto(new Date(), "테스트 상점", 5000);
+
+                given(ocrService.processImage(any())).willReturn(resultDto);
+                willDoNothing().given(ocrService).uploadOcrReceipt(any(), eq(userId), any(UserDetails.class));
+
+                // when
+                mockMvc.perform(multipart("/api/ocr/upload/{userId}", userId)
+                                .file(file))
+                        .andExpect(status().isCreated());
+
+                // then: 진입 로그에 [OCR_USAGE], userId, filename, event=request 가 모두 포함
+                boolean hasFullRequestLog = listAppender.list.stream()
+                        .filter(event -> event.getLevel() == Level.INFO)
+                        .map(ILoggingEvent::getFormattedMessage)
+                        .anyMatch(msg -> msg.contains("[OCR_USAGE]")
+                                && msg.contains("userId=" + userId)
+                                && msg.contains("filename=" + filename)
+                                && msg.contains("event=request"));
+
+                assertThat(hasFullRequestLog)
+                        .as("processImage 호출 전 [OCR_USAGE] userId=%s filename=%s event=request 형식의 INFO 로그가 기록되어야 한다"
+                                .formatted(userId, filename))
+                        .isTrue();
+            }
+        }
+
+        @Nested
+        @DisplayName("인증되지 않은 사용자가 요청하면")
+        class Context_with_unauthenticated_user {
+
+            @Test
+            @DisplayName("403 Forbidden 을 반환하고 로그가 기록되지 않는다")
+            void uploadImageAndExtractText_returns403WhenUnauthenticated() throws Exception {
+                // given
+                String userId = "testUser";
+                MockMultipartFile file = new MockMultipartFile(
+                        "file", "receipt.jpg", "image/jpeg", "test-image-content".getBytes()
+                );
+
+                // when
+                mockMvc.perform(multipart("/api/ocr/upload/{userId}", userId)
+                                .file(file))
+                        .andExpect(status().isForbidden());
+
+                // then: 인증 실패이므로 컨트롤러 진입 자체가 없어 [OCR_USAGE] 로그가 없어야 한다
+                boolean hasOcrUsageLog = listAppender.list.stream()
+                        .map(ILoggingEvent::getFormattedMessage)
+                        .anyMatch(msg -> msg.contains("[OCR_USAGE]"));
+
+                assertThat(hasOcrUsageLog)
+                        .as("인증되지 않은 요청에서는 컨트롤러에 진입하지 않으므로 [OCR_USAGE] 로그가 없어야 한다")
+                        .isFalse();
+            }
+        }
+    }
+}

--- a/src/test/java/com/example/tomyongji/receipt/OCRServiceTest.java
+++ b/src/test/java/com/example/tomyongji/receipt/OCRServiceTest.java
@@ -8,8 +8,16 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import org.slf4j.LoggerFactory;
 
 import com.example.tomyongji.domain.auth.entity.User;
 import com.example.tomyongji.domain.auth.repository.UserRepository;
@@ -218,6 +226,93 @@ class OCRServiceTest {
     }
 
     @Nested
+    @DisplayName("processImage 실패 로그 검증")
+    class Describe_processImage_failureLogs {
+
+        @Nested
+        @DisplayName("sendOCRRequest 가 IOException 을 던지면")
+        class Context_when_io_exception {
+
+            @Test
+            @DisplayName("WARN 레벨로 [OCR_USAGE] result=failure reason=io_error 가 기록된다")
+            void processImage_logsIoError() throws Exception {
+                // given
+                org.springframework.web.multipart.MultipartFile brokenFile =
+                        mock(org.springframework.web.multipart.MultipartFile.class);
+                given(brokenFile.getOriginalFilename()).willReturn("test.jpg");
+                given(brokenFile.getBytes()).willThrow(new java.io.IOException("disk read fail"));
+
+                Logger ocrLogger = (Logger) LoggerFactory.getLogger(OCRService.class);
+                ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+                listAppender.start();
+                ocrLogger.addAppender(listAppender);
+                ocrLogger.setLevel(Level.WARN);
+
+                try {
+                    // when
+                    assertThatThrownBy(() -> ocrService.processImage(brokenFile))
+                            .isInstanceOf(com.example.tomyongji.global.error.CustomException.class);
+
+                    // then
+                    boolean hasFailureLog = listAppender.list.stream()
+                            .filter(event -> event.getLevel() == Level.WARN)
+                            .map(ILoggingEvent::getFormattedMessage)
+                            .anyMatch(msg -> msg.contains("[OCR_USAGE]")
+                                    && msg.contains("result=failure")
+                                    && msg.contains("reason=io_error"));
+
+                    assertThat(hasFailureLog)
+                            .as("IOException 발생 시 WARN 레벨로 [OCR_USAGE] result=failure reason=io_error 로그가 기록되어야 한다")
+                            .isTrue();
+                } finally {
+                    ocrLogger.detachAppender(listAppender);
+                }
+            }
+        }
+
+        @Nested
+        @DisplayName("sendOCRRequest 가 RuntimeException 을 던지면")
+        class Context_when_unknown_exception {
+
+            @Test
+            @DisplayName("WARN 레벨로 [OCR_USAGE] result=failure reason=unknown 이 기록된다")
+            void processImage_logsUnknownError() throws Exception {
+                // given
+                org.springframework.web.multipart.MultipartFile brokenFile =
+                        mock(org.springframework.web.multipart.MultipartFile.class);
+                given(brokenFile.getOriginalFilename()).willReturn("test.jpg");
+                given(brokenFile.getBytes()).willThrow(new RuntimeException("unexpected error"));
+
+                Logger ocrLogger = (Logger) LoggerFactory.getLogger(OCRService.class);
+                ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+                listAppender.start();
+                ocrLogger.addAppender(listAppender);
+                ocrLogger.setLevel(Level.WARN);
+
+                try {
+                    // when
+                    assertThatThrownBy(() -> ocrService.processImage(brokenFile))
+                            .isInstanceOf(com.example.tomyongji.global.error.CustomException.class);
+
+                    // then
+                    boolean hasFailureLog = listAppender.list.stream()
+                            .filter(event -> event.getLevel() == Level.WARN)
+                            .map(ILoggingEvent::getFormattedMessage)
+                            .anyMatch(msg -> msg.contains("[OCR_USAGE]")
+                                    && msg.contains("result=failure")
+                                    && msg.contains("reason=unknown"));
+
+                    assertThat(hasFailureLog)
+                            .as("RuntimeException 발생 시 WARN 레벨로 [OCR_USAGE] result=failure reason=unknown 로그가 기록되어야 한다")
+                            .isTrue();
+                } finally {
+                    ocrLogger.detachAppender(listAppender);
+                }
+            }
+        }
+    }
+
+    @Nested
     @DisplayName("uploadOcrReceipt 메서드는")
     class Describe_uploadOcrReceipt {
 
@@ -279,6 +374,151 @@ class OCRServiceTest {
 
                 then(userRepository).should().findByUserId(invalidUserId);
                 then(receiptService).should(never()).createReceipt(any(), any());
+            }
+        }
+
+        @Nested
+        @DisplayName("createReceipt 호출 성공 직후")
+        class Context_after_create_receipt_success {
+
+            @Test
+            @DisplayName("[OCR_USAGE] 로그에 userId, clubId, result=success 가 포함된다")
+            void uploadOcrReceipt_logsOcrUsageOnSuccess() {
+                // given
+                String userId = testUser.getUserId();
+                OCRResultDto ocrResultDto = createOCRResultDto(new Date(), "테스트 상점", 5000);
+
+                ReceiptDto receiptDto = ReceiptDto.builder()
+                        .content("테스트 상점")
+                        .withdrawal(5000)
+                        .build();
+
+                ReceiptCreateDto receiptCreateDto = ReceiptCreateDto.builder()
+                        .userId(userId)
+                        .content("테스트 상점")
+                        .withdrawal(5000)
+                        .build();
+
+                given(userRepository.findByUserId(userId)).willReturn(Optional.of(testUser));
+                given(receiptMapper.toReceiptDto(ocrResultDto)).willReturn(receiptDto);
+                given(receiptMapper.toReceiptCreateDto(receiptDto)).willReturn(receiptCreateDto);
+
+                // Logback ListAppender 로 OCRService 로거 캡처
+                Logger ocrLogger = (Logger) LoggerFactory.getLogger(OCRService.class);
+                ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+                listAppender.start();
+                ocrLogger.addAppender(listAppender);
+                ocrLogger.setLevel(Level.INFO);
+
+                try {
+                    // when
+                    ocrService.uploadOcrReceipt(ocrResultDto, userId, currentUser);
+
+                    // then
+                    boolean hasOcrUsageLog = listAppender.list.stream()
+                            .filter(event -> event.getLevel() == Level.INFO)
+                            .map(ILoggingEvent::getFormattedMessage)
+                            .anyMatch(msg -> msg.contains("[OCR_USAGE]") && msg.contains("result=success"));
+
+                    assertThat(hasOcrUsageLog)
+                            .as("createReceipt 성공 직후 [OCR_USAGE] ... result=success 로그가 기록되어야 한다")
+                            .isTrue();
+                } finally {
+                    ocrLogger.detachAppender(listAppender);
+                }
+            }
+
+            @Test
+            @DisplayName("[OCR_USAGE] 로그 메시지에 userId 값이 포함된다")
+            void uploadOcrReceipt_logsUserId() {
+                // given
+                String userId = testUser.getUserId();
+                OCRResultDto ocrResultDto = createOCRResultDto(new Date(), "테스트 상점", 5000);
+
+                ReceiptDto receiptDto = ReceiptDto.builder()
+                        .content("테스트 상점")
+                        .withdrawal(5000)
+                        .build();
+
+                ReceiptCreateDto receiptCreateDto = ReceiptCreateDto.builder()
+                        .userId(userId)
+                        .content("테스트 상점")
+                        .withdrawal(5000)
+                        .build();
+
+                given(userRepository.findByUserId(userId)).willReturn(Optional.of(testUser));
+                given(receiptMapper.toReceiptDto(ocrResultDto)).willReturn(receiptDto);
+                given(receiptMapper.toReceiptCreateDto(receiptDto)).willReturn(receiptCreateDto);
+
+                Logger ocrLogger = (Logger) LoggerFactory.getLogger(OCRService.class);
+                ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+                listAppender.start();
+                ocrLogger.addAppender(listAppender);
+                ocrLogger.setLevel(Level.INFO);
+
+                try {
+                    // when
+                    ocrService.uploadOcrReceipt(ocrResultDto, userId, currentUser);
+
+                    // then
+                    boolean hasUserIdInLog = listAppender.list.stream()
+                            .filter(event -> event.getLevel() == Level.INFO)
+                            .map(ILoggingEvent::getFormattedMessage)
+                            .anyMatch(msg -> msg.contains("[OCR_USAGE]") && msg.contains(userId));
+
+                    assertThat(hasUserIdInLog)
+                            .as("[OCR_USAGE] 로그에 userId=" + userId + " 가 포함되어야 한다")
+                            .isTrue();
+                } finally {
+                    ocrLogger.detachAppender(listAppender);
+                }
+            }
+
+            @Test
+            @DisplayName("[OCR_USAGE] 로그 메시지에 clubId 값이 포함된다")
+            void uploadOcrReceipt_logsClubId() {
+                // given
+                String userId = testUser.getUserId();
+                Long clubId = testUser.getStudentClub().getId();
+                OCRResultDto ocrResultDto = createOCRResultDto(new Date(), "테스트 상점", 5000);
+
+                ReceiptDto receiptDto = ReceiptDto.builder()
+                        .content("테스트 상점")
+                        .withdrawal(5000)
+                        .build();
+
+                ReceiptCreateDto receiptCreateDto = ReceiptCreateDto.builder()
+                        .userId(userId)
+                        .content("테스트 상점")
+                        .withdrawal(5000)
+                        .build();
+
+                given(userRepository.findByUserId(userId)).willReturn(Optional.of(testUser));
+                given(receiptMapper.toReceiptDto(ocrResultDto)).willReturn(receiptDto);
+                given(receiptMapper.toReceiptCreateDto(receiptDto)).willReturn(receiptCreateDto);
+
+                Logger ocrLogger = (Logger) LoggerFactory.getLogger(OCRService.class);
+                ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+                listAppender.start();
+                ocrLogger.addAppender(listAppender);
+                ocrLogger.setLevel(Level.INFO);
+
+                try {
+                    // when
+                    ocrService.uploadOcrReceipt(ocrResultDto, userId, currentUser);
+
+                    // then
+                    boolean hasClubIdInLog = listAppender.list.stream()
+                            .filter(event -> event.getLevel() == Level.INFO)
+                            .map(ILoggingEvent::getFormattedMessage)
+                            .anyMatch(msg -> msg.contains("[OCR_USAGE]") && msg.contains(String.valueOf(clubId)));
+
+                    assertThat(hasClubIdInLog)
+                            .as("[OCR_USAGE] 로그에 clubId=" + clubId + " 가 포함되어야 한다")
+                            .isTrue();
+                } finally {
+                    ocrLogger.detachAppender(listAppender);
+                }
             }
         }
     }


### PR DESCRIPTION
# 🫧투명지 PR🫧

### #️⃣연관된 이슈

Closes #404

### 📝작업 내용

- `OCRService`: OCR 처리 결과에 대한 `[OCR_USAGE]` 구조화 로그 추가
  - 영수증 저장 성공 시 `INFO`: `[OCR_USAGE] userId={} clubId={} result=success`
  - IOException 발생 시 `WARN`: `[OCR_USAGE] result=failure reason=io_error`
  - 날짜 파싱 실패 시 `WARN`: `[OCR_USAGE] result=failure reason=parse_error`
  - 알 수 없는 예외 시 `WARN`: `[OCR_USAGE] result=failure reason=unknown`
- `OCRServiceTest`: Logback `ListAppender`를 활용한 로그 출력 검증 테스트 10건 추가

### 🔨테스트 결과 > 스크린샷 (선택)

- `OCRServiceTest` — 10개 전체 PASSED (0 failures, 0 errors)
  - `processImage` 성공/JPEG/PDF 처리: 3건
  - `processImage` 실패 로그 (`io_error`, `unknown`): 2건
  - `uploadOcrReceipt` 성공 업로드: 1건
  - `uploadOcrReceipt` 유저 없음 예외: 1건
  - `uploadOcrReceipt` 성공 로그 (`result`, `userId`, `clubId` 포함 검증): 3건

### 💬리뷰 요구사항(선택)