### PR TITLE
feat(408): Swagger API별 에러 응답 예시 커스텀 어노테이션 적용

### DIFF
--- a/src/main/java/com/example/tomyongji/config/SwaggerConfig.java
+++ b/src/main/java/com/example/tomyongji/config/SwaggerConfig.java
@@ -1,21 +1,76 @@
 package com.example.tomyongji.config;
 
+import com.example.tomyongji.global.annotation.ApiErrorExample;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.examples.Example;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.springdoc.core.customizers.OperationCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
 
-/**
- * Swagger springdoc-ui 구성 파일
- */
 @Configuration
 public class SwaggerConfig {
 
     private static final String BEARER_AUTH = "BearerAuth";
+
+    @Bean
+    public OperationCustomizer apiErrorExamplesCustomizer() {
+        return (operation, handlerMethod) -> {
+            ApiErrorExample[] errorExamples = handlerMethod.getMethod()
+                .getAnnotationsByType(ApiErrorExample.class);
+
+            if (errorExamples.length == 0) return operation;
+
+            if (operation.getResponses() == null) {
+                operation.setResponses(new ApiResponses());
+            }
+
+            Map<Integer, List<ApiErrorExample>> grouped = Arrays.stream(errorExamples)
+                .collect(Collectors.groupingBy(ApiErrorExample::status));
+
+            grouped.forEach((status, examples) -> {
+                MediaType mediaType = new MediaType();
+                examples.forEach(ex -> {
+                    Map<String, Object> body = new LinkedHashMap<>();
+                    body.put("statusCode", ex.status());
+                    body.put("message", ex.message());
+                    body.put("data", null);
+                    mediaType.addExamples(ex.message(), new Example().value(body));
+                });
+
+                Content content = new Content().addMediaType("application/json", mediaType);
+                ApiResponse apiResponse = new ApiResponse()
+                    .description(resolveDescription(status))
+                    .content(content);
+
+                operation.getResponses().addApiResponse(String.valueOf(status), apiResponse);
+            });
+
+            return operation;
+        };
+    }
+
+    private String resolveDescription(int status) {
+        try {
+            return HttpStatus.valueOf(status).getReasonPhrase();
+        } catch (IllegalArgumentException e) {
+            return String.valueOf(status);
+        }
+    }
 
     @Bean
     public OpenAPI openAPI() {

--- a/src/main/java/com/example/tomyongji/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/example/tomyongji/domain/admin/controller/AdminController.java
@@ -1,6 +1,9 @@
 package com.example.tomyongji.domain.admin.controller;
 
+import com.example.tomyongji.global.annotation.ApiErrorExample;
+import com.example.tomyongji.global.annotation.ApiErrorExamples;
 import com.example.tomyongji.global.common.response.ApiResponse;
+import com.example.tomyongji.global.error.ErrorMsg;
 import com.example.tomyongji.domain.admin.dto.MemberDto;
 import com.example.tomyongji.domain.admin.dto.PresidentDto;
 import com.example.tomyongji.domain.admin.service.AdminService;
@@ -23,6 +26,10 @@ public class AdminController {
     private final AdminService adminService;
 
     @Operation(summary = "학생회장 조회 api", description = "학생회 아이디를 통해 특정 학생회의 회장을 조회합니다.")
+    @ApiErrorExamples({
+        @ApiErrorExample(status = 400, message = ErrorMsg.NOT_FOUND_STUDENT_CLUB),
+        @ApiErrorExample(status = 400, message = ErrorMsg.NOT_FOUND_PRESIDENT)
+    })
     @GetMapping("/president/{clubId}")
     public ResponseEntity<ApiResponse<PresidentDto>> getPresident(@PathVariable("clubId") Long clubId) {
         PresidentDto presidentDto = adminService.getPresident(clubId);
@@ -31,6 +38,10 @@ public class AdminController {
     }
 
     @Operation(summary = "학생회장 저장 api", description = "학생회 아이디와 학번, 이름을 통해 특정 학생회의 회장 정보를 저장합니다.")
+    @ApiErrorExamples({
+        @ApiErrorExample(status = 400, message = ErrorMsg.EXISTING_USER),
+        @ApiErrorExample(status = 400, message = ErrorMsg.NOT_FOUND_STUDENT_CLUB)
+    })
     @PostMapping("/president")
     public ResponseEntity<ApiResponse<PresidentDto>> savePresident(@RequestBody PresidentDto presidentDto) {
         PresidentDto response = adminService.savePresident(presidentDto);
@@ -39,6 +50,7 @@ public class AdminController {
     }
 
     @Operation(summary = "학생회장 수정 api", description = "학생회 아이디와 학번, 이름을 통해 특정 학생회의 회장 정보를 수정합니다.")
+    @ApiErrorExample(status = 400, message = ErrorMsg.NOT_FOUND_STUDENT_CLUB)
     @PatchMapping("/president")
     public ResponseEntity<ApiResponse<PresidentDto>> updatePresident(@RequestBody PresidentDto presidentDto) {
         PresidentDto response = adminService.updatePresident(presidentDto);
@@ -46,6 +58,7 @@ public class AdminController {
     }
 
     @Operation(summary = "소속 부원 조회 api", description = "학생회 아이디로 소속 부원을 조회합니다.")
+    @ApiErrorExample(status = 400, message = ErrorMsg.NOT_FOUND_STUDENT_CLUB)
     @GetMapping("/member/{clubId}")
     public ResponseEntity<ApiResponse<List<MemberDto>>> getMembers(@PathVariable("clubId") Long clubId) {
         List<MemberDto> users = adminService.getMembers(clubId);
@@ -53,6 +66,10 @@ public class AdminController {
     }
 
     @Operation(summary = "소속 부원 저장 api", description = "학생회 아이디로 소속 부원 정보를 저장합니다.")
+    @ApiErrorExamples({
+        @ApiErrorExample(status = 400, message = ErrorMsg.EXISTING_USER),
+        @ApiErrorExample(status = 400, message = ErrorMsg.NOT_FOUND_STUDENT_CLUB)
+    })
     @PostMapping("/member")
     public ResponseEntity<ApiResponse<MemberDto>> saveMember(@RequestBody AdminSaveMemberDto memberDto) {
         MemberDto response = adminService.saveMember(memberDto);
@@ -60,6 +77,7 @@ public class AdminController {
     }
 
     @Operation(summary = "소속 부원 삭제 api", description = "소속 부원 아이디로 소속 부원을 삭제합니다.")
+    @ApiErrorExample(status = 400, message = ErrorMsg.NOT_FOUND_MEMBER)
     @DeleteMapping("/member/{memberId}")
     public ResponseEntity<ApiResponse<MemberDto>> deleteMember(@PathVariable("memberId") Long memberId) {
         MemberDto memberDto = adminService.deleteMember(memberId);

--- a/src/main/java/com/example/tomyongji/domain/auth/controller/EmailController.java
+++ b/src/main/java/com/example/tomyongji/domain/auth/controller/EmailController.java
@@ -1,6 +1,8 @@
 package com.example.tomyongji.domain.auth.controller;
 
+import com.example.tomyongji.global.annotation.ApiErrorExample;
 import com.example.tomyongji.global.common.response.ApiResponse;
+import com.example.tomyongji.global.error.ErrorMsg;
 import com.example.tomyongji.domain.auth.dto.EmailDto;
 import com.example.tomyongji.domain.auth.dto.VerifyDto;
 import com.example.tomyongji.domain.auth.service.EmailService;
@@ -21,6 +23,7 @@ public class EmailController {
     private final EmailService emailService;
 
     @Operation(summary = "이메일 전송 api", description = "인증번호를 이메일로 발송합니다.")
+    @ApiErrorExample(status = 400, message = ErrorMsg.ERROR_SEND_EMAIL)
     @PostMapping("/emailCheck")
     public ResponseEntity<ApiResponse<Void>> emailCheck(@RequestBody EmailDto emailDTO) throws MessagingException {
         emailService.sendSimpleMessage(emailDTO.getEmail());
@@ -29,6 +32,7 @@ public class EmailController {
     }
     
     @Operation(summary = "이메일 인증코드 확인 api", description = "사용자가 적은 인증코드를 비교합니다")
+    @ApiErrorExample(status = 401, message = "인증 코드가 일치하지 않습니다.")
     @ResponseBody
     @PostMapping("/verifyCode")
     public ResponseEntity<ApiResponse<Boolean>> verifyCode(@RequestBody VerifyDto verifyDto) {

--- a/src/main/java/com/example/tomyongji/domain/auth/controller/PasswordResetController.java
+++ b/src/main/java/com/example/tomyongji/domain/auth/controller/PasswordResetController.java
@@ -3,7 +3,9 @@ package com.example.tomyongji.domain.auth.controller;
 import com.example.tomyongji.domain.auth.dto.PasswordResetConfirmDto;
 import com.example.tomyongji.domain.auth.dto.PasswordResetRequestDto;
 import com.example.tomyongji.domain.auth.service.PasswordResetService;
+import com.example.tomyongji.global.annotation.ApiErrorExample;
 import com.example.tomyongji.global.common.response.ApiResponse;
+import com.example.tomyongji.global.error.ErrorMsg;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -23,6 +25,7 @@ public class PasswordResetController {
     private final PasswordResetService passwordResetService;
 
     @Operation(summary = "비밀번호 재설정 메일 발송 api", description = "입력한 이메일로 비밀번호 재설정 링크를 발송합니다. 이메일 존재 여부와 무관하게 항상 성공 응답을 반환합니다.")
+    @ApiErrorExample(status = 422, message = ErrorMsg.ERROR_SEND_EMAIL)
     @PostMapping("/reset-request")
     public ResponseEntity<ApiResponse<Void>> requestReset(@Valid @RequestBody PasswordResetRequestDto dto) {
         passwordResetService.requestPasswordReset(dto.getEmail());
@@ -30,6 +33,7 @@ public class PasswordResetController {
     }
 
     @Operation(summary = "[개발용]비밀번호 재설정 메일 발송 api", description = "입력한 이메일로 비밀번호 재설정 링크를 발송합니다. 이메일 존재 여부와 무관하게 항상 성공 응답을 반환합니다.")
+    @ApiErrorExample(status = 422, message = ErrorMsg.ERROR_SEND_EMAIL)
     @PostMapping("/reset-request-dev")
     public ResponseEntity<ApiResponse<Void>> requestResetDev(@Valid @RequestBody PasswordResetRequestDto dto) {
         passwordResetService.requestPasswordResetTest(dto.getEmail());
@@ -37,6 +41,7 @@ public class PasswordResetController {
     }
 
     @Operation(summary = "비밀번호 재설정 확인 api", description = "이메일로 받은 토큰과 새 비밀번호를 입력하여 비밀번호를 변경합니다.")
+    @ApiErrorExample(status = 400, message = ErrorMsg.INVALID_TOKEN)
     @PostMapping("/reset-confirm")
     public ResponseEntity<ApiResponse<Void>> confirmReset(@Valid @RequestBody PasswordResetConfirmDto dto) {
         passwordResetService.confirmPasswordReset(dto.getToken(), dto.getNewPassword());

--- a/src/main/java/com/example/tomyongji/domain/auth/controller/UserController.java
+++ b/src/main/java/com/example/tomyongji/domain/auth/controller/UserController.java
@@ -1,6 +1,9 @@
 package com.example.tomyongji.domain.auth.controller;
 
+import com.example.tomyongji.global.annotation.ApiErrorExample;
+import com.example.tomyongji.global.annotation.ApiErrorExamples;
 import com.example.tomyongji.global.common.response.ApiResponse;
+import com.example.tomyongji.global.error.ErrorMsg;
 import com.example.tomyongji.domain.auth.dto.ClubVerifyRequestDto;
 import com.example.tomyongji.domain.auth.dto.FindIdRequestDto;
 import com.example.tomyongji.domain.auth.dto.LoginRequestDto;
@@ -27,6 +30,14 @@ public class UserController {
     private final UserService userService;
 
     @Operation(summary = "회원가입 api", description = "사용자가 회원가입하면, 유효성검사후 회원가입합니다.")
+    @ApiErrorExamples({
+        @ApiErrorExample(status = 400, message = ErrorMsg.NOT_FOUND_COLLEGE),
+        @ApiErrorExample(status = 400, message = ErrorMsg.NOT_FOUND_STUDENT_CLUB),
+        @ApiErrorExample(status = 400, message = ErrorMsg.NOT_HAVE_STUDENT_CLUB),
+        @ApiErrorExample(status = 400, message = ErrorMsg.EXISTING_USER),
+        @ApiErrorExample(status = 400, message = ErrorMsg.NOT_VERIFY_EMAIL),
+        @ApiErrorExample(status = 400, message = ErrorMsg.NOT_VERIFY_CLUB)
+    })
     @PostMapping("/signup")
     public ResponseEntity<ApiResponse<Long>> signUp(@Valid @RequestBody UserRequestDto userRequestDto){
         Long id = userService.signUp(userRequestDto);
@@ -36,6 +47,7 @@ public class UserController {
     }
 
     @Operation(summary = "유저 아이디 중복 검사 api", description = "사용자가 ID 중복검사를 누르면 중복 검사합니다. ")
+    @ApiErrorExample(status = 409, message = "이미 존재하는 아이디입니다.")
     @GetMapping("/{userId}")
     public ResponseEntity<ApiResponse<Boolean>> checkUserIdDuplicate(@PathVariable("userId") String userId){
         boolean isDuplicate = userService.checkUserIdDuplicate(userId);
@@ -57,6 +69,7 @@ public class UserController {
     }
 
     @Operation(summary = "아이디 찾기 API", description = "이메일을 넣으면 ID를 찾아줍니다.")
+    @ApiErrorExample(status = 400, message = ErrorMsg.NOT_FOUND_USER_EMAIL)
     @PostMapping("/find-id")
     public ResponseEntity<ApiResponse<String>> findUserIdByEmail(@RequestBody FindIdRequestDto findIdRequest){
         String id = userService.findUserIdByEmail(findIdRequest.getEmail());
@@ -64,6 +77,12 @@ public class UserController {
     }
 
     @Operation(summary = "소속 인증 API", description = "사용자 id와 학생회 id를 넣으면 소속인증을 합니다.")
+    @ApiErrorExamples({
+        @ApiErrorExample(status = 400, message = ErrorMsg.NOT_FOUND_STUDENT_CLUB),
+        @ApiErrorExample(status = 400, message = ErrorMsg.NOT_FOUND_MEMBER),
+        @ApiErrorExample(status = 400, message = ErrorMsg.NOT_FOUND_PRESIDENT),
+        @ApiErrorExample(status = 400, message = ErrorMsg.INCORRECT_ROLE_VALUE)
+    })
     @PostMapping("/clubVerify")
     public ResponseEntity<ApiResponse<Boolean>> VerifyClub(@RequestBody ClubVerifyRequestDto clubVerifyDto) {
         boolean isClubVerify = userService.verifyClub(clubVerifyDto);
@@ -71,6 +90,7 @@ public class UserController {
     }
 
     @Operation(summary = "회원탈퇴 API", description = "사용자가 회원탈퇴를 합니다.")
+    @ApiErrorExample(status = 400, message = ErrorMsg.NOT_FOUND_USER)
     @DeleteMapping("/delete")
     public ResponseEntity<ApiResponse<Void>> deleteUser(@AuthenticationPrincipal UserDetails currentUser) {
         String userId = currentUser.getUsername();

--- a/src/main/java/com/example/tomyongji/domain/my/controller/MyController.java
+++ b/src/main/java/com/example/tomyongji/domain/my/controller/MyController.java
@@ -1,7 +1,10 @@
 package com.example.tomyongji.domain.my.controller;
 
 import com.example.tomyongji.domain.my.dto.CollegeAndClubResponseDto;
+import com.example.tomyongji.global.annotation.ApiErrorExample;
+import com.example.tomyongji.global.annotation.ApiErrorExamples;
 import com.example.tomyongji.global.common.response.ApiResponse;
+import com.example.tomyongji.global.error.ErrorMsg;
 import com.example.tomyongji.domain.admin.dto.MemberDto;
 import com.example.tomyongji.domain.my.dto.MyDto;
 import com.example.tomyongji.domain.my.dto.SaveMemberDto;
@@ -34,6 +37,11 @@ public class MyController {
 
 
     @Operation(summary = "내 정보 조회 api", description = "유저 아이디를 통해 유저 정보를 조회합니다.")
+    @ApiErrorExamples({
+        @ApiErrorExample(status = 400, message = ErrorMsg.NOT_FOUND_USER),
+        @ApiErrorExample(status = 400, message = ErrorMsg.MISMATCHED_USER),
+        @ApiErrorExample(status = 400, message = ErrorMsg.NOT_FOUND_STUDENT_CLUB)
+    })
     @GetMapping("/{id}")
     public ResponseEntity<ApiResponse<MyDto>> getMyInfo(
         @PathVariable("id") Long id,
@@ -46,6 +54,10 @@ public class MyController {
 
 
     @Operation(summary = "내 소속 대학 및 학생회 조회 api", description = "현재 로그인한 유저의 소속 대학과 학생회를 조회합니다.")
+    @ApiErrorExamples({
+        @ApiErrorExample(status = 400, message = ErrorMsg.NOT_FOUND_USER),
+        @ApiErrorExample(status = 400, message = ErrorMsg.NOT_FOUND_STUDENT_CLUB)
+    })
     @GetMapping("college-and-club")
     public ResponseEntity<ApiResponse<CollegeAndClubResponseDto>> getMyCollegeAndClub(@AuthenticationPrincipal UserDetails currentUser) {
         CollegeAndClubResponseDto myCollegeAndClub = myService.getMyCollegeAndClub(currentUser);
@@ -59,6 +71,10 @@ public class MyController {
 //    }
 
     @Operation(summary = "소속 부원 조회 api", description = "회장이 소속 부원들을 조회합니다.")
+    @ApiErrorExamples({
+        @ApiErrorExample(status = 400, message = ErrorMsg.NOT_FOUND_USER),
+        @ApiErrorExample(status = 400, message = ErrorMsg.MISMATCHED_USER)
+    })
     @GetMapping("members/{id}") //자신의 아이디로 자기가 속한 학생회 조회
     public ResponseEntity<ApiResponse<List<MemberDto>>> getMembers(
         @PathVariable("id") Long id,
@@ -70,6 +86,12 @@ public class MyController {
     }
 
     @Operation(summary = "소속 부원 추가 api", description = "회장이 소속 부원 정보를 추가합니다.")
+    @ApiErrorExamples({
+        @ApiErrorExample(status = 400, message = ErrorMsg.NOT_FOUND_USER),
+        @ApiErrorExample(status = 400, message = ErrorMsg.MISMATCHED_USER),
+        @ApiErrorExample(status = 400, message = ErrorMsg.EXISTING_USER),
+        @ApiErrorExample(status = 400, message = ErrorMsg.NOT_FOUND_STUDENT_CLUB)
+    })
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("members") //회장이 자신의 유저 아이디로 자기가 속한 학생회 조회
     public ResponseEntity<ApiResponse<MemberDto>> saveMember(
@@ -81,6 +103,11 @@ public class MyController {
     }
 
     @Operation(summary = "소속 부원 삭제 api", description = "회장이 소속 부원과 그 정보를 삭제합니다.")
+    @ApiErrorExamples({
+        @ApiErrorExample(status = 400, message = ErrorMsg.NOT_FOUND_MEMBER),
+        @ApiErrorExample(status = 400, message = ErrorMsg.NOT_FOUND_USER),
+        @ApiErrorExample(status = 400, message = ErrorMsg.NO_AUTHORIZATION_BELONGING)
+    })
     @DeleteMapping("members/{deletedStudentNum}") //삭제할 멤버 아이디를 통한 삭제
     public ResponseEntity<ApiResponse<MemberDto>> deleteMember(
         @PathVariable("deletedStudentNum") String deletedStudentNum,

--- a/src/main/java/com/example/tomyongji/domain/receipt/controller/BreakDownController.java
+++ b/src/main/java/com/example/tomyongji/domain/receipt/controller/BreakDownController.java
@@ -1,6 +1,9 @@
 package com.example.tomyongji.domain.receipt.controller;
 
+import com.example.tomyongji.global.annotation.ApiErrorExample;
+import com.example.tomyongji.global.annotation.ApiErrorExamples;
 import com.example.tomyongji.global.common.response.ApiResponse;
+import com.example.tomyongji.global.error.ErrorMsg;
 import com.example.tomyongji.domain.receipt.dto.BreakDownDto;
 import com.example.tomyongji.domain.receipt.dto.ReceiptDto;
 import com.example.tomyongji.domain.receipt.service.BreakDownService;
@@ -25,6 +28,13 @@ public class BreakDownController {
     private final BreakDownService breakDownService;
 
     @Operation(summary = "PDF 거래내역서 파싱 api", description = "PDF 파일을 업로드하여 거래내역을 파싱합니다.")
+    @ApiErrorExamples({
+        @ApiErrorExample(status = 400, message = ErrorMsg.NOT_FOUND_USER),
+        @ApiErrorExample(status = 400, message = ErrorMsg.NOT_FOUND_STUDENT_CLUB),
+        @ApiErrorExample(status = 400, message = ErrorMsg.EMPTY_FILE),
+        @ApiErrorExample(status = 403, message = ErrorMsg.NO_AUTHORIZATION_BELONGING),
+        @ApiErrorExample(status = 500, message = ErrorMsg.PARSING_ERROR)
+    })
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/parse")
     public ResponseEntity<ApiResponse<List<ReceiptDto>>> parsePdfFile(

--- a/src/main/java/com/example/tomyongji/domain/receipt/controller/CsvController.java
+++ b/src/main/java/com/example/tomyongji/domain/receipt/controller/CsvController.java
@@ -1,6 +1,9 @@
 package com.example.tomyongji.domain.receipt.controller;
 
+import com.example.tomyongji.global.annotation.ApiErrorExample;
+import com.example.tomyongji.global.annotation.ApiErrorExamples;
 import com.example.tomyongji.global.common.response.ApiResponse;
+import com.example.tomyongji.global.error.ErrorMsg;
 import com.example.tomyongji.domain.receipt.dto.CsvExportDto;
 import com.example.tomyongji.domain.receipt.entity.Receipt;
 import com.example.tomyongji.domain.receipt.service.CSVService;
@@ -29,6 +32,10 @@ public class CsvController {
     private final CSVService csvService;
 
     @Operation(summary = "CSV 업로드 api", description = "엑셀 CSV 파일을 업로드하여 영수증 데이터를 불러옵니다.")
+    @ApiErrorExamples({
+        @ApiErrorExample(status = 400, message = ErrorMsg.NOT_FOUND_USER),
+        @ApiErrorExample(status = 400, message = ErrorMsg.NO_AUTHORIZATION_BELONGING)
+    })
     @PostMapping("/upload/{userIndexId}")
     public ResponseEntity<ApiResponse<List<Receipt>>> readCsv(@RequestPart("file") MultipartFile file, @PathVariable long userIndexId, @AuthenticationPrincipal
         UserDetails currentUser) {
@@ -39,6 +46,10 @@ public class CsvController {
     }
 
     @Operation(summary = "CSV 내보내기 api", description = "영수증 데이터를 CSV 파일로 내보냅니다.")
+    @ApiErrorExamples({
+        @ApiErrorExample(status = 400, message = ErrorMsg.NOT_FOUND_USER),
+        @ApiErrorExample(status = 400, message = ErrorMsg.NO_AUTHORIZATION_BELONGING)
+    })
     @PostMapping("/export")
     public ResponseEntity<ApiResponse<Void>> exportCsv(@RequestBody CsvExportDto csvExportDto, HttpServletResponse response, @AuthenticationPrincipal UserDetails currentUser) {
         csvService.writeCsv(response,csvExportDto, currentUser);

--- a/src/main/java/com/example/tomyongji/domain/receipt/controller/ExcelController.java
+++ b/src/main/java/com/example/tomyongji/domain/receipt/controller/ExcelController.java
@@ -5,7 +5,10 @@ import com.example.tomyongji.domain.receipt.dto.ExcelStatusResponseDto;
 import com.example.tomyongji.domain.receipt.service.ExcelAnalyzeService;
 import com.example.tomyongji.domain.receipt.service.ExcelConfirmService;
 import com.example.tomyongji.domain.receipt.service.ExcelUploadService;
+import com.example.tomyongji.global.annotation.ApiErrorExample;
+import com.example.tomyongji.global.annotation.ApiErrorExamples;
 import com.example.tomyongji.global.common.response.ApiResponse;
+import com.example.tomyongji.global.error.ErrorMsg;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -22,6 +25,12 @@ public class ExcelController {
     private final ExcelUploadService excelUploadService;
     private final ExcelConfirmService excelConfirmService;
 
+    @ApiErrorExamples({
+        @ApiErrorExample(status = 400, message = ErrorMsg.NOT_FOUND_USER),
+        @ApiErrorExample(status = 400, message = ErrorMsg.EXCEL_PARSE_ERROR),
+        @ApiErrorExample(status = 401, message = ErrorMsg.NOT_HAVE_STUDENT_CLUB),
+        @ApiErrorExample(status = 500, message = ErrorMsg.GEMINI_API_ERROR)
+    })
     @PostMapping("/analyze")
     public ResponseEntity<ApiResponse<ExcelStatusResponseDto>> analyze(
         @RequestPart("file") MultipartFile file,
@@ -31,6 +40,14 @@ public class ExcelController {
         return ResponseEntity.ok(ApiResponse.onSuccess(result));
     }
 
+    @ApiErrorExamples({
+        @ApiErrorExample(status = 400, message = ErrorMsg.NOT_FOUND_USER),
+        @ApiErrorExample(status = 400, message = ErrorMsg.NOT_FOUND_MAPPING_RULE),
+        @ApiErrorExample(status = 400, message = ErrorMsg.EXCEL_PARSE_ERROR),
+        @ApiErrorExample(status = 401, message = ErrorMsg.NOT_HAVE_STUDENT_CLUB),
+        @ApiErrorExample(status = 422, message = ErrorMsg.MAPPING_RULE_MISMATCH),
+        @ApiErrorExample(status = 500, message = ErrorMsg.EXCEL_REDIS_ERROR)
+    })
     @PostMapping("/upload")
     public ResponseEntity<ApiResponse<ExcelStatusResponseDto>> upload(
         @RequestPart("file") MultipartFile file,
@@ -40,6 +57,12 @@ public class ExcelController {
         return ResponseEntity.ok(ApiResponse.onSuccess(result));
     }
 
+    @ApiErrorExamples({
+        @ApiErrorExample(status = 400, message = ErrorMsg.NOT_FOUND_USER),
+        @ApiErrorExample(status = 400, message = ErrorMsg.NO_AUTHORIZATION_BELONGING),
+        @ApiErrorExample(status = 400, message = ErrorMsg.EXCEL_PREVIEW_EXPIRED),
+        @ApiErrorExample(status = 404, message = ErrorMsg.NOT_FOUND_STUDENT_CLUB)
+    })
     @PostMapping("/confirm")
     public ResponseEntity<ApiResponse<Integer>> confirm(
         @RequestBody ExcelConfirmRequestDto requestDto,

--- a/src/main/java/com/example/tomyongji/domain/receipt/controller/OCRController.java
+++ b/src/main/java/com/example/tomyongji/domain/receipt/controller/OCRController.java
@@ -1,6 +1,9 @@
 package com.example.tomyongji.domain.receipt.controller;
 
+import com.example.tomyongji.global.annotation.ApiErrorExample;
+import com.example.tomyongji.global.annotation.ApiErrorExamples;
 import com.example.tomyongji.global.common.response.ApiResponse;
+import com.example.tomyongji.global.error.ErrorMsg;
 import com.example.tomyongji.domain.receipt.dto.OCRResultDto;
 import com.example.tomyongji.domain.receipt.service.OCRService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -30,6 +33,15 @@ public class OCRController {
 
 
     @Operation(summary = "영수증 업로드 api", description = "유저 아이디를 통해 특정 학생회의 영수증을 ocr 스캔을 통해 업로드합니다.")
+    @ApiErrorExamples({
+        @ApiErrorExample(status = 400, message = "지원하지 않는 파일 형식입니다."),
+        @ApiErrorExample(status = 400, message = ErrorMsg.NOT_FOUND_USER),
+        @ApiErrorExample(status = 500, message = "OCR 요청 중 I/O 오류가 발생했습니다."),
+        @ApiErrorExample(status = 500, message = "OCR 응답 날짜 파싱에 실패했습니다."),
+        @ApiErrorExample(status = 500, message = "OCR 처리 중 예외가 발생했습니다."),
+        @ApiErrorExample(status = 500, message = "OCR 처리 결과 금액이 0입니다."),
+        @ApiErrorExample(status = 502, message = "OCR API 호출 실패")
+    })
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/upload/{userId}")
     public ResponseEntity<ApiResponse<OCRResultDto>> uploadImageAndExtractText(@RequestPart("file") MultipartFile file, @PathVariable("userId") String userId, @AuthenticationPrincipal

--- a/src/main/java/com/example/tomyongji/domain/receipt/controller/ReceiptController.java
+++ b/src/main/java/com/example/tomyongji/domain/receipt/controller/ReceiptController.java
@@ -1,6 +1,9 @@
 package com.example.tomyongji.domain.receipt.controller;
 
+import com.example.tomyongji.global.annotation.ApiErrorExample;
+import com.example.tomyongji.global.annotation.ApiErrorExamples;
 import com.example.tomyongji.global.common.response.ApiResponse;
+import com.example.tomyongji.global.error.ErrorMsg;
 import com.example.tomyongji.domain.receipt.service.ReceiptService;
 import com.example.tomyongji.domain.receipt.dto.PagingReceiptDto;
 import com.example.tomyongji.domain.receipt.dto.ReceiptByStudentClubDto;
@@ -35,6 +38,12 @@ public class ReceiptController {
     private final ReceiptService receiptService;
 
     @Operation(summary = "영수증 작성 api", description = "유저 아이디를 통해 특정 학생회의 영수증을 작성합니다.")
+    @ApiErrorExamples({
+        @ApiErrorExample(status = 400, message = ErrorMsg.NOT_FOUND_USER),
+        @ApiErrorExample(status = 400, message = ErrorMsg.NO_AUTHORIZATION_BELONGING),
+        @ApiErrorExample(status = 400, message = ErrorMsg.DUPLICATED_FLOW),
+        @ApiErrorExample(status = 400, message = ErrorMsg.EMPTY_CONTENT)
+    })
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping //특정 학생회의 영수증 작성
     public ResponseEntity<ApiResponse<ReceiptDto>> createReceipt(@RequestBody ReceiptCreateDto receiptCreateDto, @AuthenticationPrincipal UserDetails currentUser) {
@@ -53,6 +62,10 @@ public class ReceiptController {
 
 
     @Operation(summary = "특정 학생회 영수증 조회 api", description = "학생회 아이디를 통해 특정 학생회의 영수증을 조회합니다.")
+    @ApiErrorExamples({
+        @ApiErrorExample(status = 400, message = ErrorMsg.NOT_FOUND_USER),
+        @ApiErrorExample(status = 400, message = ErrorMsg.NO_AUTHORIZATION_BELONGING)
+    })
     @GetMapping("/club/{id}") //특정 학생회 영수증 조회
     public ResponseEntity<ApiResponse<ReceiptByStudentClubDto>> getReceiptsByClub(@PathVariable("id") Long id, @AuthenticationPrincipal UserDetails currentUser) {
         ReceiptByStudentClubDto receipts = receiptService.getReceiptsByClub(id, currentUser);
@@ -61,6 +74,7 @@ public class ReceiptController {
     }
 
     @Operation(summary = "특정 학생회 영수증 조회 일반 학생용 api", description = "학생회 아이디를 통해 특정 학생회의 영수증을 조회합니다.")
+    @ApiErrorExample(status = 400, message = ErrorMsg.NOT_FOUND_STUDENT_CLUB)
     @GetMapping("/club/{clubId}/student") //특정 학생회 영수증 조회
     public ResponseEntity<ApiResponse<List<ReceiptDto>>> getReceiptsByClubForStudent(@PathVariable("clubId") Long clubId) {
         List<ReceiptDto> receipts = receiptService.getReceiptsByClubForStudent(clubId);
@@ -69,6 +83,10 @@ public class ReceiptController {
     }
 
     @Operation(summary = "특정 학생회 영수증 페이지별 조회 일반 학생용 api", description = "학생회 아이디와 페이지 정보, 영수증 수를 통해 특정 학생회의 영수증을 조회합니다.")
+    @ApiErrorExamples({
+        @ApiErrorExample(status = 400, message = ErrorMsg.NOT_FOUND_STUDENT_CLUB),
+        @ApiErrorExample(status = 400, message = ErrorMsg.INVALID_DATE_SEARCH)
+    })
     @GetMapping("/club/{clubId}/paging")
     public ResponseEntity<ApiResponse<PagingReceiptDto>> getReceiptsByClubPaging(
         @PathVariable("clubId") Long clubId,
@@ -96,6 +114,7 @@ public class ReceiptController {
     }
 
     @Operation(summary = "특정 영수증 조회 api", description = "영수증 아이디를 통해 특정 영수증을 조회합니다.")
+    @ApiErrorExample(status = 400, message = ErrorMsg.NOT_FOUND_RECEIPT)
     @GetMapping("/{receiptId}") //특정 영수증 조회
     public ResponseEntity<ApiResponse<ReceiptDto>> getReceiptById(@PathVariable("receiptId") Long receiptId) {
         ReceiptDto receipt = receiptService.getReceiptById(receiptId);
@@ -107,6 +126,11 @@ public class ReceiptController {
 
 
     @Operation(summary = "영수증 삭제 api", description = "영수증 아이디를 통해 특정 영수증을 삭제합니다.")
+    @ApiErrorExamples({
+        @ApiErrorExample(status = 400, message = ErrorMsg.NOT_FOUND_RECEIPT),
+        @ApiErrorExample(status = 400, message = ErrorMsg.NO_AUTHORIZATION_BELONGING),
+        @ApiErrorExample(status = 400, message = ErrorMsg.NOT_FOUND_STUDENT_CLUB)
+    })
     @DeleteMapping("/{receiptId}") //특정 영수증 삭제
     public ResponseEntity<ApiResponse<ReceiptDto>> deleteReceipt(@PathVariable("receiptId") Long receiptId, @AuthenticationPrincipal UserDetails currentUser) {
         ReceiptDto receipt = receiptService.deleteReceipt(receiptId, currentUser);
@@ -115,6 +139,12 @@ public class ReceiptController {
     }
 
     @Operation(summary = "영수증 수정 api", description = "영수증 아이디를 통해 특정 영수증을 수정합니다.")
+    @ApiErrorExamples({
+        @ApiErrorExample(status = 400, message = ErrorMsg.NOT_FOUND_RECEIPT),
+        @ApiErrorExample(status = 400, message = ErrorMsg.NO_AUTHORIZATION_BELONGING),
+        @ApiErrorExample(status = 400, message = ErrorMsg.DUPLICATED_FLOW),
+        @ApiErrorExample(status = 400, message = ErrorMsg.EMPTY_CONTENT)
+    })
     @PutMapping //특정 영수증 수정
     public ResponseEntity<ApiResponse<ReceiptDto>> updateReceipt(@RequestBody ReceiptDto receiptDto, @AuthenticationPrincipal UserDetails currentUser) {
         ReceiptDto updatedReceipt = receiptService.updateReceipt(receiptDto, currentUser);
@@ -123,6 +153,10 @@ public class ReceiptController {
     }
 
     @Operation(summary = "영수증 검색 api", description = "두 글자 이상의 검색어를 통해 특정 영수증을 조회합니다.")
+    @ApiErrorExamples({
+        @ApiErrorExample(status = 400, message = ErrorMsg.NOT_FOUND_USER),
+        @ApiErrorExample(status = 400, message = ErrorMsg.INVALID_KEYWORD)
+    })
     @GetMapping("/keyword") //특정 영수증 수정
     public ResponseEntity<ApiResponse<List<ReceiptDto>>> searchReceiptByKeyword(@RequestParam String keyword, @AuthenticationPrincipal UserDetails currentUser) {
         List<ReceiptDto> receipts = receiptService.searchReceiptByKeyword(keyword, currentUser);

--- a/src/main/java/com/example/tomyongji/domain/receipt/controller/StudentClubController.java
+++ b/src/main/java/com/example/tomyongji/domain/receipt/controller/StudentClubController.java
@@ -2,7 +2,10 @@ package com.example.tomyongji.domain.receipt.controller;
 
 import com.example.tomyongji.domain.receipt.dto.ClubMemberResponseDto;
 import com.example.tomyongji.domain.receipt.dto.ClubTransferRequestDto;
+import com.example.tomyongji.global.annotation.ApiErrorExample;
+import com.example.tomyongji.global.annotation.ApiErrorExamples;
 import com.example.tomyongji.global.common.response.ApiResponse;
+import com.example.tomyongji.global.error.ErrorMsg;
 import com.example.tomyongji.domain.admin.dto.PresidentDto;
 import com.example.tomyongji.domain.receipt.dto.ClubDto;
 import com.example.tomyongji.domain.receipt.dto.TransferDto;
@@ -44,6 +47,11 @@ public class StudentClubController {
     }
 
     @Operation(summary = "학생회 소속 인원 전체 조회 api", description = "특정 학생회에 속한 모든 인원의 학번 및 이름을 가나다순 조회합니다.")
+    @ApiErrorExamples({
+        @ApiErrorExample(status = 400, message = ErrorMsg.NOT_FOUND_USER),
+        @ApiErrorExample(status = 400, message = ErrorMsg.NOT_FOUND_STUDENT_CLUB),
+        @ApiErrorExample(status = 403, message = ErrorMsg.NO_AUTHORIZATION_ROLE)
+    })
     @GetMapping("api/club/members")
     public ResponseEntity<ApiResponse<List<ClubMemberResponseDto>>> getClubMembers(@AuthenticationPrincipal UserDetails currentUser) {
         List<ClubMemberResponseDto> members = studentClubService.getClubMemberList(currentUser);
@@ -51,6 +59,11 @@ public class StudentClubController {
     }
 
     @Operation(summary = "학생회 이월/이전 api", description = "학생회 정보를 이월 합니다.")
+    @ApiErrorExamples({
+        @ApiErrorExample(status = 400, message = ErrorMsg.NOT_FOUND_USER),
+        @ApiErrorExample(status = 400, message = ErrorMsg.NOT_FOUND_STUDENT_CLUB),
+        @ApiErrorExample(status = 403, message = ErrorMsg.NO_AUTHORIZATION_ROLE)
+    })
     @PostMapping("api/club/transfer")
     public ResponseEntity<ApiResponse<TransferDto>> transferStudentClub(
         @RequestBody(required = false) PresidentDto request,
@@ -64,6 +77,13 @@ public class StudentClubController {
     }
 
     @Operation(summary = "학생회 이월/이전 및 잔류인원 저장 api", description = "학생회 영수증 정보 및 학생회장 잔류인원 정보를 이월 합니다.")
+    @ApiErrorExamples({
+        @ApiErrorExample(status = 400, message = ErrorMsg.NOT_FOUND_USER),
+        @ApiErrorExample(status = 400, message = ErrorMsg.NOT_FOUND_STUDENT_CLUB),
+        @ApiErrorExample(status = 400, message = ErrorMsg.CANNOT_RE_ELECT_PRESIDENT),
+        @ApiErrorExample(status = 400, message = ErrorMsg.ALREADY_BELONGING_USER),
+        @ApiErrorExample(status = 403, message = ErrorMsg.NO_AUTHORIZATION_ROLE)
+    })
     @PostMapping("api/club/transfer-and-user")
     public ResponseEntity<ApiResponse<TransferDto>> transferStudentClubUser(
             @RequestBody(required = false) ClubTransferRequestDto request,

--- a/src/main/java/com/example/tomyongji/global/annotation/ApiErrorExample.java
+++ b/src/main/java/com/example/tomyongji/global/annotation/ApiErrorExample.java
@@ -1,0 +1,11 @@
+package com.example.tomyongji.global.annotation;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Repeatable(ApiErrorExamples.class)
+public @interface ApiErrorExample {
+    int status() default 400;
+    String message();
+}

--- a/src/main/java/com/example/tomyongji/global/annotation/ApiErrorExamples.java
+++ b/src/main/java/com/example/tomyongji/global/annotation/ApiErrorExamples.java
@@ -1,0 +1,9 @@
+package com.example.tomyongji.global.annotation;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ApiErrorExamples {
+    ApiErrorExample[] value();
+}


### PR DESCRIPTION
Closes #408

### 📝작업 내용

**커스텀 어노테이션 정의**
- `@ApiErrorExample(status, message)` — `@Repeatable` 패턴으로 단일/복수 모두 지원
- `@ApiErrorExamples` — 컨테이너 어노테이션
- 기존 `ErrorMsg` 상수를 그대로 재활용, 별도 ErrorCode enum 생성 없음

**Swagger OperationCustomizer 구현**
- `SwaggerConfig`에 `apiErrorExamplesCustomizer()` 빈 추가
- 동일 상태코드 에러를 하나의 응답 블록 내 Examples 드롭다운으로 그루핑
- 각 Example body: `{"statusCode": N, "message": "...", "data": null}` 형식

**11개 컨트롤러 전체 적용**
- `UserController`, `ReceiptController`, `AdminController`, `EmailController`, `PasswordResetController`, `MyController`, `StudentClubController`, `CsvController`, `ExcelController`, `OCRController`, `BreakDownController`
- 각 메서드별 발생 가능한 모든 `CustomException` 명시 (`NO_AUTHORIZATION_USER` 인프라 예외만 제외)

### 🔨테스트 결과
- Swagger 화면 예시
<img width="1088" height="674" alt="image" src="https://github.com/user-attachments/assets/32cd6d5f-421b-43b8-8e9a-ba1fa5b6053a" />


`GET /v3/api-docs` 호출로 전체 검증 완료

| API | 응답코드 | Examples |
|---|---|---|
| 유저ID 중복검사 | 200, 409 | 이미 존재하는 아이디입니다. |
| 영수증 작성 | 201, 400 | 유저를 찾을 수 없습니다. \| 접근 권한이 없습니다 \| 입금과 출금 둘 중 하나만 적어주세요. \| 학생회비 사용 내용을 작성해주세요. |
| 특정 학생회 영수증 조회 | 200, 400 | 유저를 찾을 수 없습니다. \| 접근 권한이 없습니다 |
| 영수증 조회 학생용 | 200, 400 | 학생회를 찾을 수 없습니다. |
| 영수증 페이징 | 200, 400 | 학생회를 찾을 수 없습니다. \| 연도 없이 월만 검색 불가 |
| 영수증 삭제 | 200, 400 | 영수증을 찾을 수 없습니다. \| 접근 권한이 없습니다 \| 학생회를 찾을 수 없습니다. |
| OCR 업로드 | 201, 400, 500, 502 | 400: 지원하지 않는 파일 형식 \| 유저 없음 / 500: IO·파싱·예외·금액0 / 502: API 호출 실패 |
| 엑셀 분석 | 200, 400, 401, 500 | NOT_FOUND_USER \| EXCEL_PARSE_ERROR \| NOT_HAVE_STUDENT_CLUB \| GEMINI_API_ERROR |
| 엑셀 업로드 | 200, 400, 401, 422, 500 | NOT_FOUND_USER \| NOT_FOUND_MAPPING_RULE \| EXCEL_PARSE_ERROR \| NOT_HAVE_STUDENT_CLUB \| MAPPING_RULE_MISMATCH \| EXCEL_REDIS_ERROR |
| 엑셀 확정 | 200, 400, 404 | 400: 유저 없음 \| 접근 권한 없음 \| 미리보기 만료 / 404: 학생회 없음 |
| CSV 업로드/내보내기 | 200, 400 | 유저를 찾을 수 없습니다. \| 접근 권한이 없습니다 |
| PDF 파싱 | 201, 400, 403, 500 | 유저 없음 \| 학생회 없음 \| 파일 없음 \| 접근 권한 없음 \| 파싱 오류 |
| 학생회 이월 | 200, 400, 403 | 유저 없음 \| 학생회 없음 \| 권한 없음 |
| 학생회 이월+인원 | 200, 400, 403 | 유저 없음 \| 학생회 없음 \| 연임 불가 \| 타 소속 유저 \| 권한 없음 |

### 💬리뷰 요구사항

- `NO_AUTHORIZATION_USER`(checkClub에서 인증된 유저 DB 미존재 시)는 인프라 레벨 예외로 판단해 전체 제외했습니다. 이 기준이 적절한지 확인 부탁드립니다.